### PR TITLE
MMCA - 4052 Date error identification #5878

### DIFF
--- a/app/forms/mappings/LocalDateFormatter.scala
+++ b/app/forms/mappings/LocalDateFormatter.scala
@@ -87,7 +87,7 @@ private[mappings] class LocalDateFormatter(
           _.map(fe => fe.copy(key = fe.key, args = args))
         }
       case _ =>
-        Left(List(FormError(updateFormErrorKeysInCaseOfEmptyValues(key, data), invalidKey, args)))
+        Left(List(FormError(formErrorKeysInCaseOfEmptyOrNonNumericValues(key, data), invalidKey, args)))
     }
   }
 
@@ -125,25 +125,25 @@ private[mappings] class LocalDateFormatter(
   /**
    * Updates the FormError key as per the given criteria
    * key is updated as below
-   * empty day - key.day
-   * empty month - key.month
-   * empty year - key.year
+   * empty day or non numeric day - key.day
+   * empty month or non numeric month - key.month
+   * empty year or non numeric year - key.year
    *
    * @param key FormError key
    * @param data Map of Form values
    * @return Updated FormError key
    */
-  private[mappings] def updateFormErrorKeysInCaseOfEmptyValues(key: String,
-                                                               data: Map[String, String]): String = {
+  private[mappings] def formErrorKeysInCaseOfEmptyOrNonNumericValues(key: String,
+                                                                     data: Map[String, String]): String = {
 
-    val dayValue: Option[String] = data.get(s"$key.day")
+    val dayValue = data.get(s"$key.day")
     val monthValue = data.get(s"$key.month")
     val yearValue = data.get(s"$key.year")
 
     (dayValue, monthValue, yearValue) match {
-      case (Some(d), _, _) if d.isEmpty => s"$key.day"
-      case (_, Some(m), _) if m.isEmpty => s"$key.month"
-      case (_, _, Some(y)) if y.isEmpty => s"$key.year"
+      case (Some(d), _, _) if d.trim.isEmpty || Try(d.trim.toInt).isFailure => s"$key.day"
+      case (_, Some(m), _) if m.trim.isEmpty || Try(m.trim.toInt).isFailure => s"$key.month"
+      case (_, _, Some(y)) if y.trim.isEmpty || Try(y.trim.toInt).isFailure => s"$key.year"
       case _ => s"$key.day"
     }
   }

--- a/app/forms/mappings/LocalDateFormatter.scala
+++ b/app/forms/mappings/LocalDateFormatter.scala
@@ -16,9 +16,10 @@
 
 package forms.mappings
 
-import play.api.{Logger, LoggerLike}
 import play.api.data.FormError
 import play.api.data.format.Formatter
+import play.api.{Logger, LoggerLike}
+
 import java.time.{LocalDate, LocalDateTime}
 import scala.util.{Failure, Success, Try}
 
@@ -32,20 +33,24 @@ private[mappings] class LocalDateFormatter(
   val log: LoggerLike = Logger(this.getClass)
   val currentDate: LocalDate = LocalDateTime.now().toLocalDate
 
-  private def getEndDay(month: Int, year: Int, date: LocalDate) = {
-    if(month == currentDate.getMonthValue && year == currentDate.getYear){
-      log.info("entered month: "+month+"; entered year: "+year)
-      log.info("current month: "+currentDate.getMonthValue+"; currentyear: "+ currentDate.getYear)
+  private def getEndDay(month: Int, year: Int, date: LocalDate): Int = {
+    if (month == currentDate.getMonthValue && year == currentDate.getYear) {
+      log.info("entered month: " + month + "; entered year: " + year)
+      log.info("current month: " + currentDate.getMonthValue + "; currentyear: " + currentDate.getYear)
       currentDate.getDayOfMonth
     } else {
       date.lengthOfMonth()
     }
   }
 
-  private def toDate(key: String, day:Int, month: Int, year: Int): Either[Seq[FormError], LocalDate] = {
+  private def toDate(key: String,
+                     day: Int,
+                     month: Int,
+                     year: Int): Either[Seq[FormError], LocalDate] = {
     Try(LocalDate.of(year, month, day)) match {
-      case Success(date) => Right(LocalDate.of(year, month, day))
-      case Failure(_) => Left(Seq(FormError(key, invalidKey, args)))
+      case Success(_) => Right(LocalDate.of(year, month, day))
+      case Failure(_) =>
+        Left(Seq(FormError(updateFormErrorKeys(key, day, month, year), invalidKey, args)))
     }
   }
 
@@ -59,14 +64,17 @@ private[mappings] class LocalDateFormatter(
     )
 
     for {
-      day <- int.bind(s"$key.day", data).right
-      month <- int.bind(s"$key.month", data).right
-      year <- int.bind(s"$key.year", data).right
-      date <- toDate(key, day, month, year).right
-    } yield date
+      day <- int.bind(s"$key.day", data)
+      month <- int.bind(s"$key.month", data)
+      year <- int.bind(s"$key.year", data)
+      date <- toDate(key, day, month, year)
+    } yield {
+      date
+    }
   }
 
-  override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], LocalDate] = {
+  override def bind(key: String,
+                    data: Map[String, String]): Either[Seq[FormError], LocalDate] = {
 
     val fields = fieldKeys.map {
       field =>
@@ -76,10 +84,10 @@ private[mappings] class LocalDateFormatter(
     fields.count(_._2.isDefined) match {
       case 2 =>
         formatDate(key, data).left.map {
-          _.map(_.copy(key = key, args = args))
+          _.map(fe => fe.copy(key = fe.key, args = args))
         }
       case _ =>
-        Left(List(FormError(key, invalidKey, args)))
+        Left(List(FormError(updateFormErrorKeysInCaseOfEmptyValues(key, data), invalidKey, args)))
     }
   }
 
@@ -89,4 +97,54 @@ private[mappings] class LocalDateFormatter(
       s"$key.month" -> value.getMonthValue.toString,
       s"$key.year" -> value.getYear.toString
     )
+
+  /**
+   * Updates the FormError key as per valid day, month and year criteria
+   * key is updated as below
+   * invalid day - key.day
+   * invalid month - key.month
+   * invalid year - key.year
+   *
+   * @param key Input form key
+   * @param day Day value of the input date
+   * @param month Month value of the input date
+   * @param year Year value of the input date
+   * @return Updated form key
+   */
+  private[mappings] def updateFormErrorKeys(key: String,
+                                            day: Int,
+                                            month: Int,
+                                            year: Int): String =
+    (day, month, year) match {
+      case (d, _, _) if d < 1 || d > 31 => s"$key.day"
+      case (_, m, _) if m < 1 || m > 12 => s"$key.month"
+      case (_, _, y) if y < 1000 || y > 999999999 => s"$key.year"
+      case _ => s"$key.day"
+    }
+
+  /**
+   * Updates the FormError key as per the given criteria
+   * key is updated as below
+   * empty day - key.day
+   * empty month - key.month
+   * empty year - key.year
+   *
+   * @param key FormError key
+   * @param data Map of Form values
+   * @return Updated FormError key
+   */
+  private[mappings] def updateFormErrorKeysInCaseOfEmptyValues(key: String,
+                                                               data: Map[String, String]): String = {
+
+    val dayValue: Option[String] = data.get(s"$key.day")
+    val monthValue = data.get(s"$key.month")
+    val yearValue = data.get(s"$key.year")
+
+    (dayValue, monthValue, yearValue) match {
+      case (Some(d), _, _) if d.isEmpty => s"$key.day"
+      case (_, Some(m), _) if m.isEmpty => s"$key.month"
+      case (_, _, Some(y)) if y.isEmpty => s"$key.year"
+      case _ => s"$key.day"
+    }
+  }
 }

--- a/app/forms/mappings/LocalDateFormatter.scala
+++ b/app/forms/mappings/LocalDateFormatter.scala
@@ -118,7 +118,7 @@ private[mappings] class LocalDateFormatter(
     (day, month, year) match {
       case (d, _, _) if d < 1 || d > 31 => s"$key.day"
       case (_, m, _) if m < 1 || m > 12 => s"$key.month"
-      case (_, _, y) if y < 1000 || y > 999999999 => s"$key.year"
+      case (_, _, y) if y < 1000 || y > 99999 => s"$key.year"
       case _ => s"$key.day"
     }
 
@@ -135,7 +135,6 @@ private[mappings] class LocalDateFormatter(
    */
   private[mappings] def formErrorKeysInCaseOfEmptyOrNonNumericValues(key: String,
                                                                      data: Map[String, String]): String = {
-
     val dayValue = data.get(s"$key.day")
     val monthValue = data.get(s"$key.month")
     val yearValue = data.get(s"$key.year")

--- a/app/helpers/FormHelper.scala
+++ b/app/helpers/FormHelper.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helpers
+
+object FormHelper {
+
+  /**
+   * Updates the key as per below validation
+   * If key is either start or end and error msg is among future date,etmp date or tax year date
+   *  Updated key - start.day
+   *
+   *  If key is either start or end and error msg is of invalid year length
+   *   Updated key - start.year
+   *
+   *  If key is other than start or end
+   *   Updated key is unchanged
+   *
+   * @return Updated FormError key
+   */
+  def updateFormErrorKeyForStartAndEndDate(): (String, String) => String = (key: String, errorMsg: String) => {
+    val futureStartDateMsgKey = "cf.form.error.start-future-date"
+    val etmpStartDateMsgKey = "cf.form.error.startDate.date-earlier-than-system-start-date"
+    val taxYearStartDateMsgKey = "cf.form.error.start.date-too-far-in-past"
+
+    val futureEndDateMsgKey = "cf.form.error.end-future-date"
+    val etmpEndDateMsgKey = "cf.form.error.endDate.date-earlier-than-system-start-date"
+    val taxYearEndDateMsgKey = "cf.form.error.end.date-too-far-in-past"
+
+    val startDateMsgKeyList = List(futureStartDateMsgKey, etmpStartDateMsgKey, taxYearStartDateMsgKey)
+    val endDateMsgKeyList = List(futureEndDateMsgKey, etmpEndDateMsgKey, taxYearEndDateMsgKey)
+
+    if ((key.equals("start") || key.equals("end"))) {
+      if (startDateMsgKeyList.contains(errorMsg) || endDateMsgKeyList.contains(errorMsg))
+        s"$key.day"
+      else
+        s"$key.year"
+    } else {
+      key
+    }
+  }
+}

--- a/app/views/cash_transactions_request_page.scala.html
+++ b/app/views/cash_transactions_request_page.scala.html
@@ -14,6 +14,8 @@
  * limitations under the License.
  *@
 
+@import helpers.FormHelper.updateFormErrorKeyForStartAndEndDate
+
 @this(
     main_template: Layout,
     formHelper: FormWithCSRF,
@@ -34,7 +36,7 @@
 ) {
 
     @formHelper(action = controllers.routes.RequestTransactionsController.onSubmit(), 'autoComplete -> "off") {
-        @errorSummary(form.errors,errorFieldName = None)
+        @errorSummary(form.errors,errorFieldName = None, isErrorKeyUpdateEnabled = true, Some(updateFormErrorKeyForStartAndEndDate))
         @h1("cf.cash-account.transactions.request.heading")
         @p("cf.cash-account.transactions.request.p")
 

--- a/app/views/components/errorSummary.scala.html
+++ b/app/views/components/errorSummary.scala.html
@@ -16,12 +16,15 @@
 
 @this(govukErrorSummary: GovukErrorSummary)
 
-@(errors: Seq[FormError], errorFieldName: Option[String])(implicit messages: Messages)
+@(errors: Seq[FormError],
+errorFieldName: Option[String],
+isErrorKeyUpdateEnabled: Boolean = false,
+updateFormErrorKeyForTheMessage:Option[(String, String) => String] = None)(implicit messages: Messages)
 
 @if(errors.nonEmpty) {
     @defining(errors.map { error =>
         ErrorLink(
-            href = Some(s"#${errorFieldName.getOrElse(s"${error.key}.month")}"),
+            href = Some(s"#${errorFieldName.getOrElse(if(isErrorKeyUpdateEnabled) updateFormErrorKeyForTheMessage.get(s"${error.key}", error.message) else s"${error.key}")}"),
             content = Text(messages(error.message, error.args:_*))
         )
     }) { errorLinks =>

--- a/test/forms/CashTransactionsRequestPageFormProviderSpec.scala
+++ b/test/forms/CashTransactionsRequestPageFormProviderSpec.scala
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.FormTestHelper._
+import models.CashTransactionDates
+import utils.SpecBase
+
+import java.time.{Clock, LocalDate, ZoneOffset}
+
+class CashTransactionsRequestPageFormProviderSpec extends SpecBase {
+
+  "apply" must {
+
+    "populate CashTransactionDates form correctly (or with correct error) for input start date" when {
+
+      "start date is valid" in new SetUp {
+        form.bind(completeValidDates).get mustBe CashTransactionDates(start = validDate, end = validDate)
+      }
+
+      "the day of start date is blank " in new SetUp {
+        val startDate = populateFormValueMap("start", "","10","2021")
+        val validEndDate = populateFormValueMap("end", "10","10","2021")
+        val formData = startDate ++ validEndDate
+
+        val expectedErrors = error("start.day", "cf.form.error.start.date-number-invalid")
+
+         checkForError(form, formData, expectedErrors)
+      }
+
+      "the month of start date is blank " in new SetUp {
+        val startDate = populateFormValueMap("start", "10", "", "2021")
+        val validEndDate = populateFormValueMap("end", "10", "10", "2021")
+        val formData = startDate ++ validEndDate
+
+        val expectedErrors = error("start.month", "cf.form.error.start.date-number-invalid")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "the year of start date is blank " in new SetUp {
+        val startDate = populateFormValueMap("start", "10", "10", "")
+        val validEndDate = populateFormValueMap("end", "10", "10", "2021")
+        val formData = startDate ++ validEndDate
+
+        val expectedErrors = error("start.year", "cf.form.error.start.date-number-invalid")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "the day value is invalid for the start date" in new SetUp {
+        val startDate = populateFormValueMap("start", "40", "10", "2021")
+        val validEndDate = populateFormValueMap("end", "10", "10", "2021")
+        val formData = startDate ++ validEndDate
+
+        val expectedErrors = error("start.day", "cf.form.error.start.date-number-invalid")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "the month value is invalid for the start date" in new SetUp {
+        val startDate = populateFormValueMap("start", "10", "14", "2021")
+        val validEndDate = populateFormValueMap("end", "10", "10", "2021")
+        val formData = startDate ++ validEndDate
+
+        val expectedErrors = error("start.month", "cf.form.error.start.date-number-invalid")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "the year value is invalid for the start date" in new SetUp {
+        val startDate = populateFormValueMap("start", "10", "10", "-")
+        val validEndDate = populateFormValueMap("end", "10", "10", "2021")
+        val formData = startDate ++ validEndDate
+
+        val expectedErrors = error("start.year", "cf.form.error.start.date-number-invalid")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "start date is in future" in new SetUp {
+        val startDate = populateFormValueMap("start", "10", "10", futureYear.toString)
+        val validEndDate = populateFormValueMap("end", "10", "10", "2021")
+        val formData = startDate ++ validEndDate
+
+        val expectedErrors = error("start", "cf.form.error.start-future-date")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "start date has invalid length of the year" in new SetUp {
+        val startDate = populateFormValueMap("start", "10", "10", "20211")
+        val validEndDate = populateFormValueMap("end", "10", "10", "2021")
+
+        val formData: Map[String, String] = startDate ++ validEndDate
+
+        val expectedErrors = error("start", "cf.form.error.year.length")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "start date is not within ETMP statement date period" in new SetUp {
+        val startDate = populateFormValueMap("start", "10", "10", (etmpStatementYear - 1).toString)
+        val validEndDate = populateFormValueMap("end", "10", "10", "2021")
+
+        val formData: Map[String, String] = startDate ++ validEndDate
+
+        val expectedErrors = error("start", "cf.form.error.startDate.date-earlier-than-system-start-date")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      /**
+       * Below has been ignored as of now cause below condition is not occurring because
+       * ETMP Statement check is overriding this . Need to be checked with Business Team
+       */
+
+      "start date is not of a valid tax year" ignore new SetUp {
+        val startDate = populateFormValueMap("start", "10", "10", taxYearDateOlderThan6Years.toString)
+        val validEndDate = populateFormValueMap("end", "10", "10", "2021")
+
+        val formData: Map[String, String] = startDate ++ validEndDate
+
+        val expectedErrors = error("start", "cf.form.error.start.date-too-far-in-past")
+
+        checkForError(form, formData, expectedErrors)
+      }
+    }
+
+    "populate CashTransactionDates form correctly (or with correct error) for input end date" when {
+
+      "end date is valid" in new SetUp {
+        form.bind(completeValidDates).get mustBe CashTransactionDates(start = validDate, end = validDate)
+      }
+
+      "the day of end date is blank " in new SetUp {
+        val validStartDate = populateFormValueMap("start", "10", "10", "2021")
+        val endDate = populateFormValueMap("end", "", "10", "2021")
+        val formData = validStartDate ++ endDate
+
+        val expectedErrors = error("end.day", "cf.form.error.end.date-number-invalid")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "the month of end date is blank " in new SetUp {
+        val validStartDate = populateFormValueMap("start", "10", "10", "2021")
+        val endDate = populateFormValueMap("end", "10", "", "2021")
+        val formData = validStartDate ++ endDate
+
+        val expectedErrors = error("end.month", "cf.form.error.end.date-number-invalid")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "the year of end date is blank " in new SetUp {
+        val validStartDate = populateFormValueMap("start", "10", "10", "2021")
+        val endDate = populateFormValueMap("end", "10", "10", "")
+        val formData = validStartDate ++ endDate
+
+        val expectedErrors = error("end.year", "cf.form.error.end.date-number-invalid")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "the day value is invalid for the end date" in new SetUp {
+        val validStartDate = populateFormValueMap("start", "10", "10", "2021")
+        val endDate = populateFormValueMap("end", "32", "10", "2021")
+        val formData = validStartDate ++ endDate
+
+        val expectedErrors = error("end.day", "cf.form.error.end.date-number-invalid")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "the month value is invalid for the end date" in new SetUp {
+        val validStartDate = populateFormValueMap("start", "10", "10", "2021")
+        val endDate = populateFormValueMap("end", "10", "14", "2021")
+        val formData = validStartDate ++ endDate
+
+        val expectedErrors = error("end.month", "cf.form.error.end.date-number-invalid")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "the year value is invalid for the end date" in new SetUp {
+        val validStartDate = populateFormValueMap("start", "10", "10", "2021")
+        val endDate = populateFormValueMap("end", "10", "14", "-")
+        val formData = validStartDate ++ endDate
+
+        val expectedErrors = error("end.year", "cf.form.error.end.date-number-invalid")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "end date is in future" in new SetUp {
+        val validStartDate = populateFormValueMap("start", "10", "10", "2021")
+        val endDate = populateFormValueMap("end", "10", "10", futureYear.toString)
+        val formData = validStartDate ++ endDate
+
+        val expectedErrors = error("end", "cf.form.error.end-future-date")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "end date has invalid length of the year" in new SetUp {
+        val validStartDate = populateFormValueMap("start", "10", "10", "2021")
+        val endDate = populateFormValueMap("end", "10", "10", "20112")
+        val formData = validStartDate ++ endDate
+
+        val expectedErrors = error("end", "cf.form.error.year.length")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "end date is not within ETMP statement date period" in new SetUp {
+        val validStartDate = populateFormValueMap("start", "10", "10", "2021")
+        val endDate = populateFormValueMap("end", "10", "10", (etmpStatementYear - 1).toString)
+        val formData = validStartDate ++ endDate
+
+        val expectedErrors = error("end", "cf.form.error.endDate.date-earlier-than-system-start-date")
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      /**
+       * Below has been ignored as of now cause below condition is not occurring because
+       * ETMP Statement check is overriding this . Need to be checked with Business Team
+       */
+
+      "end date is not of a valid tax year" ignore new SetUp {
+        val validStartDate = populateFormValueMap("start", "10", "10", "2021")
+        val endDate = populateFormValueMap("end", "10", "10", taxYearDateOlderThan6Years.toString)
+        val formData = validStartDate ++ endDate
+
+        val expectedErrors = error("end", "cf.form.error.end.date-too-far-in-past")
+
+        checkForError(form, formData, expectedErrors)
+      }
+    }
+  }
+
+  trait SetUp {
+    implicit val clock = Clock.system(ZoneOffset.UTC)
+    val form = new CashTransactionsRequestPageFormProvider().apply()
+
+    val validDate: LocalDate = LocalDate.of(2021, 10,10)
+    val futureYear = LocalDate.now().getYear + 1
+    val etmpStatementYear = 2019 // This needs to be updated should the Year value in Constraints.etmpStatementsDate is changed
+    val taxYearDateOlderThan6Years = LocalDate.now().getYear  - 7
+
+    lazy val completeValidDates: Map[String, String] =
+      populateFormValueMap("start", "10", "10", "2021") ++
+        populateFormValueMap("end", "10", "10", "2021")
+
+    def populateFormValueMap(key: String,
+                             day: String,
+                             month: String,
+                             year: String): Map[String, String] =
+      Map(s"$key.day" -> day, s"$key.month" -> month, s"$key.year" -> year)
+  }
+}
+
+

--- a/test/forms/CashTransactionsRequestPageFormProviderSpec.scala
+++ b/test/forms/CashTransactionsRequestPageFormProviderSpec.scala
@@ -18,6 +18,7 @@ package forms
 
 import forms.FormTestHelper._
 import models.CashTransactionDates
+import play.api.data.Form
 import utils.SpecBase
 
 import java.time.{Clock, LocalDate, ZoneOffset}
@@ -255,13 +256,13 @@ class CashTransactionsRequestPageFormProviderSpec extends SpecBase {
   }
 
   trait SetUp {
-    implicit val clock = Clock.system(ZoneOffset.UTC)
-    val form = new CashTransactionsRequestPageFormProvider().apply()
+    implicit val clock: Clock = Clock.system(ZoneOffset.UTC)
+    val form: Form[CashTransactionDates] = new CashTransactionsRequestPageFormProvider().apply()
 
     val validDate: LocalDate = LocalDate.of(2021, 10,10)
-    val futureYear = LocalDate.now().getYear + 1
+    val futureYear: Int = LocalDate.now().getYear + 1
     val etmpStatementYear = 2019 // This needs to be updated should the Year value in Constraints.etmpStatementsDate is changed
-    val taxYearDateOlderThan6Years = LocalDate.now().getYear  - 7
+    val taxYearDateOlderThan6Years: Int = LocalDate.now().getYear  - 7
 
     lazy val completeValidDates: Map[String, String] =
       populateFormValueMap("start", "10", "10", "2021") ++
@@ -274,5 +275,3 @@ class CashTransactionsRequestPageFormProviderSpec extends SpecBase {
       Map(s"$key.day" -> day, s"$key.month" -> month, s"$key.year" -> year)
   }
 }
-
-

--- a/test/forms/FormTestHelper.scala
+++ b/test/forms/FormTestHelper.scala
@@ -21,7 +21,6 @@ import play.api.data.{Form, FormError}
 
 object FormTestHelper extends Matchers {
 
-
   def error(key: String, value: String): Seq[FormError] = Seq(singleError(key, value))
 
   def singleError(key: String, value: String): FormError = FormError(key, value)

--- a/test/forms/FormTestHelper.scala
+++ b/test/forms/FormTestHelper.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import org.scalatest.matchers.must.Matchers
+import play.api.data.{Form, FormError}
+
+object FormTestHelper extends Matchers {
+
+
+  def error(key: String, value: String): Seq[FormError] = Seq(singleError(key, value))
+
+  def singleError(key: String, value: String): FormError = FormError(key, value)
+
+  def checkForError(form: Form[_], data: Map[String, String], expectedErrors: Seq[FormError]): Unit = {
+    form.bind(data).fold(
+      formWithErrors => {
+        formWithErrors.errors mustBe expectedErrors
+      },
+      form => {
+        fail("Expected a validation error when binding the form, but it was bound successfully.")
+      }
+    )
+  }
+}

--- a/test/forms/mappings/LocalDateFormatterSpec.scala
+++ b/test/forms/mappings/LocalDateFormatterSpec.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.mappings
+
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import play.api.data.FormError
+import utils.SpecBase
+
+import java.time.LocalDate
+
+class LocalDateFormatterSpec extends SpecBase {
+  "bind" must {
+    "return the correct LocalDate when the supplied data is valid" in new SetUp {
+      val localDateFormatter = new LocalDateFormatter(
+        invalidMsgKey, endOfMonth = false, Seq())
+
+      localDateFormatter.bind(key, bindDataValid) shouldBe Right(LocalDate.of(2022, 10, 12))
+    }
+
+    "return the correct FormError with keys when the supplied data is invalid" in new SetUp {
+      val localDateFormatter = new LocalDateFormatter(
+        invalidMsgKey,
+        endOfMonth = false,
+        Seq())
+
+      localDateFormatter.bind(key, bindDataEmptyDate) shouldBe
+        Left(Seq(FormError("start.day", List(invalidMsgKey), List())))
+
+     localDateFormatter.bind(key, bindDataDateWithEmptyMonth) shouldBe
+        Left(Seq(FormError("start.month", List(invalidMsgKey), List())))
+
+      localDateFormatter.bind(key, bindDataDateWithEmptyYear) shouldBe
+        Left(Seq(FormError("start.year", List(invalidMsgKey), List())))
+
+      localDateFormatter.bind(key, bindDataInValidDate) shouldBe
+        Left(Seq(FormError("start.day", List(invalidMsgKey), List())))
+
+      localDateFormatter.bind(key, bindDataInValidMonth) shouldBe
+        Left(Seq(FormError("start.month", List(invalidMsgKey), List())))
+
+      localDateFormatter.bind(key, bindDataInValidYear) shouldBe
+        Left(Seq(FormError("start.year", List(invalidMsgKey), List())))
+    }
+  }
+
+  "updateFormErrorKeys" must {
+    "append the day in the existing key when day is incorrect or all(day, month and year) are incorrect" in new SetUp {
+      val localDateFormatterWithInvalidDay = new LocalDateFormatter(invalidMsgKey, endOfMonth = false, Seq())
+      localDateFormatterWithInvalidDay.updateFormErrorKeys(key, 32, 12, 2023) shouldBe s"$key.day"
+
+      localDateFormatterWithInvalidDay.updateFormErrorKeys(key, 32, 14, -1) shouldBe s"$key.day"
+    }
+
+    "append the month in the existing key when month is incorrect" in new SetUp {
+      val localDateFormatterWithInvalidMonth = new LocalDateFormatter(invalidMsgKey, endOfMonth = false, Seq())
+      localDateFormatterWithInvalidMonth.updateFormErrorKeys(key, 12, 14, 2023) shouldBe s"$key.month"
+    }
+
+    "append the year in the existing key when year is incorrect" in new SetUp {
+      val localDateFormatterWithInvalidYear = new LocalDateFormatter(invalidMsgKey, endOfMonth = false, Seq())
+      localDateFormatterWithInvalidYear.updateFormErrorKeys(key, 12, 12, -2022) shouldBe s"$key.year"
+    }
+  }
+
+  "updateFormErrorKeysInCaseOfEmptyValues" must {
+    "return key.day as updated key when day value is empty" in new SetUp {
+      val localDateFormatterWithEmptyDay = new LocalDateFormatter(invalidMsgKey, endOfMonth = false, Seq())
+      val formDataWithEmptyDay: Map[String, String] = Map(s"$key.day" -> "", s"$key.month" -> "10", s"$key.year" -> "2021")
+
+      localDateFormatterWithEmptyDay.updateFormErrorKeysInCaseOfEmptyValues(
+        key, formDataWithEmptyDay) shouldBe s"$key.day"
+    }
+
+    "return key.month as updated key when month value is empty" in new SetUp {
+      val localDateFormatterWithEmptyMonth = new LocalDateFormatter(invalidMsgKey, endOfMonth = false, Seq())
+      val formDataWithEmptyDay: Map[String, String] = Map(s"$key.day" -> "10", s"$key.month" -> "", s"$key.year" -> "2021")
+
+      localDateFormatterWithEmptyMonth.updateFormErrorKeysInCaseOfEmptyValues(
+        key, formDataWithEmptyDay) shouldBe s"$key.month"
+    }
+
+    "return key.year as updated key when year value is empty" in new SetUp {
+      val localDateFormatterWithEmptyYear = new LocalDateFormatter(invalidMsgKey, endOfMonth = false, Seq())
+      val formDataWithEmptyDay: Map[String, String] = Map(s"$key.day" -> "10", s"$key.month" -> "10", s"$key.year" -> "")
+
+      localDateFormatterWithEmptyYear.updateFormErrorKeysInCaseOfEmptyValues(
+        key, formDataWithEmptyDay) shouldBe s"$key.year"
+    }
+
+    "return key.day as updated key when all date fields are empty" in new SetUp {
+      val localDateFormatterWithEmptyDate= new LocalDateFormatter(invalidMsgKey, endOfMonth = false, Seq())
+      val formDataWithEmptyDay: Map[String, String] = Map(s"$key.day" -> "", s"$key.month" -> "", s"$key.year" -> "")
+
+      localDateFormatterWithEmptyDate.updateFormErrorKeysInCaseOfEmptyValues(
+        key, formDataWithEmptyDay) shouldBe s"$key.day"
+    }
+  }
+}
+
+trait SetUp {
+  val key = "start"
+  val invalidMsgKey = "cf.form.error.start.date-number-invalid"
+  val bindDataValid: Map[String, String] = Map("start.day" -> "12", "start.month" -> "10", "start.year" -> "2022")
+  val bindDataEmptyDate: Map[String, String] = Map("start.day" -> "", "start.month" -> "", "start.year" -> "")
+  val bindDataDateWithEmptyMonth: Map[String, String] = Map("start.day" -> "10", "start.month" -> "", "start.year" -> "2022")
+  val bindDataDateWithEmptyYear: Map[String, String] = Map("start.day" -> "10", "start.month" -> "10", "start.year" -> "")
+  val bindDataInValidDate: Map[String, String] = Map("start.day" -> "34", "start.month" -> "14", "start.year" -> "2023")
+  val bindDataInValidMonth: Map[String, String] = Map("start.day" -> "10", "start.month" -> "14", "start.year" -> "2022")
+  val bindDataInValidYear: Map[String, String] = Map("start.day" -> "10", "start.month" -> "10", "start.year" -> "-")
+}

--- a/test/forms/mappings/LocalDateFormatterSpec.scala
+++ b/test/forms/mappings/LocalDateFormatterSpec.scala
@@ -76,12 +76,12 @@ class LocalDateFormatterSpec extends SpecBase {
     }
   }
 
-  "updateFormErrorKeysInCaseOfEmptyValues" must {
+  "formErrorKeysInCaseOfEmptyOrNonNumericValues" must {
     "return key.day as updated key when day value is empty" in new SetUp {
       val localDateFormatterWithEmptyDay = new LocalDateFormatter(invalidMsgKey, endOfMonth = false, Seq())
       val formDataWithEmptyDay: Map[String, String] = Map(s"$key.day" -> "", s"$key.month" -> "10", s"$key.year" -> "2021")
 
-      localDateFormatterWithEmptyDay.updateFormErrorKeysInCaseOfEmptyValues(
+      localDateFormatterWithEmptyDay.formErrorKeysInCaseOfEmptyOrNonNumericValues(
         key, formDataWithEmptyDay) shouldBe s"$key.day"
     }
 
@@ -89,7 +89,7 @@ class LocalDateFormatterSpec extends SpecBase {
       val localDateFormatterWithEmptyMonth = new LocalDateFormatter(invalidMsgKey, endOfMonth = false, Seq())
       val formDataWithEmptyDay: Map[String, String] = Map(s"$key.day" -> "10", s"$key.month" -> "", s"$key.year" -> "2021")
 
-      localDateFormatterWithEmptyMonth.updateFormErrorKeysInCaseOfEmptyValues(
+      localDateFormatterWithEmptyMonth.formErrorKeysInCaseOfEmptyOrNonNumericValues(
         key, formDataWithEmptyDay) shouldBe s"$key.month"
     }
 
@@ -97,7 +97,7 @@ class LocalDateFormatterSpec extends SpecBase {
       val localDateFormatterWithEmptyYear = new LocalDateFormatter(invalidMsgKey, endOfMonth = false, Seq())
       val formDataWithEmptyDay: Map[String, String] = Map(s"$key.day" -> "10", s"$key.month" -> "10", s"$key.year" -> "")
 
-      localDateFormatterWithEmptyYear.updateFormErrorKeysInCaseOfEmptyValues(
+      localDateFormatterWithEmptyYear.formErrorKeysInCaseOfEmptyOrNonNumericValues(
         key, formDataWithEmptyDay) shouldBe s"$key.year"
     }
 
@@ -105,8 +105,32 @@ class LocalDateFormatterSpec extends SpecBase {
       val localDateFormatterWithEmptyDate= new LocalDateFormatter(invalidMsgKey, endOfMonth = false, Seq())
       val formDataWithEmptyDay: Map[String, String] = Map(s"$key.day" -> "", s"$key.month" -> "", s"$key.year" -> "")
 
-      localDateFormatterWithEmptyDate.updateFormErrorKeysInCaseOfEmptyValues(
+      localDateFormatterWithEmptyDate.formErrorKeysInCaseOfEmptyOrNonNumericValues(
         key, formDataWithEmptyDay) shouldBe s"$key.day"
+    }
+
+    "return key.day as updated key when day value is not numeric" in new SetUp {
+      val localDateFormatterWithEmptyDay = new LocalDateFormatter(invalidMsgKey, endOfMonth = false, Seq())
+      val formDataWithNonNumericDay: Map[String, String] = Map(s"$key.day" -> "se", s"$key.month" -> "10", s"$key.year" -> "2021")
+
+      localDateFormatterWithEmptyDay.formErrorKeysInCaseOfEmptyOrNonNumericValues(
+        key, formDataWithNonNumericDay) shouldBe s"$key.day"
+    }
+
+    "return key.month as updated key when month value is not numeric" in new SetUp {
+      val localDateFormatterWithEmptyDay = new LocalDateFormatter(invalidMsgKey, endOfMonth = false, Seq())
+      val formDataWithNonNumericMonth: Map[String, String] = Map(s"$key.day" -> "10", s"$key.month" -> "test", s"$key.year" -> "2021")
+
+      localDateFormatterWithEmptyDay.formErrorKeysInCaseOfEmptyOrNonNumericValues(
+        key, formDataWithNonNumericMonth) shouldBe s"$key.month"
+    }
+
+    "return key.year as updated key when year value is not numeric" in new SetUp {
+      val localDateFormatterWithEmptyDay = new LocalDateFormatter(invalidMsgKey, endOfMonth = false, Seq())
+      val formDataWithNonNumericYear: Map[String, String] = Map(s"$key.day" -> "10", s"$key.month" -> "10", s"$key.year" -> "et")
+
+      localDateFormatterWithEmptyDay.formErrorKeysInCaseOfEmptyOrNonNumericValues(
+        key, formDataWithNonNumericYear) shouldBe s"$key.year"
     }
   }
 }

--- a/test/helpers/FormHelperSpec.scala
+++ b/test/helpers/FormHelperSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helpers
+
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import utils.SpecBase
+
+class FormHelperSpec extends SpecBase {
+  "updateFormErrorKeyForTheMessage" must {
+    "append .day in the FormError key when key is either start or end and error msg key is " +
+      "among future date, ETMP or Tax year" in new SetUp {
+
+      FormHelper.updateFormErrorKeyForStartAndEndDate()(
+        startKey, "cf.form.error.start-future-date") shouldBe s"$startKey.day"
+
+      FormHelper.updateFormErrorKeyForStartAndEndDate()(
+        startKey, "cf.form.error.startDate.date-earlier-than-system-start-date") shouldBe s"$startKey.day"
+
+      FormHelper.updateFormErrorKeyForStartAndEndDate()(
+        startKey, "cf.form.error.start.date-too-far-in-past") shouldBe s"$startKey.day"
+
+      FormHelper.updateFormErrorKeyForStartAndEndDate()(
+        endKey, "cf.form.error.end-future-date") shouldBe s"$endKey.day"
+
+      FormHelper.updateFormErrorKeyForStartAndEndDate()(
+        endKey, "cf.form.error.endDate.date-earlier-than-system-start-date") shouldBe s"$endKey.day"
+
+      FormHelper.updateFormErrorKeyForStartAndEndDate()(
+        endKey, "cf.form.error.end.date-too-far-in-past") shouldBe s"$endKey.day"
+    }
+
+    "append .year in the FormError key when key is either start or end and " +
+      "error msg key is of invalid year length" in new SetUp {
+
+      FormHelper.updateFormErrorKeyForStartAndEndDate()(
+        startKey, "cf.form.error.year.length") shouldBe s"$startKey.year"
+
+      FormHelper.updateFormErrorKeyForStartAndEndDate()(
+        endKey, "cf.form.error.year.length") shouldBe s"$endKey.year"
+    }
+
+    "return the unchanged key when key in neither start or end" in new SetUp {
+      FormHelper.updateFormErrorKeyForStartAndEndDate()(
+        defaultKey, "cf.form.error.year.length") shouldBe defaultKey
+
+      FormHelper.updateFormErrorKeyForStartAndEndDate()(
+        defaultKey, "cf.form.error.year.length") shouldBe defaultKey
+    }
+  }
+}
+
+trait SetUp {
+  val startKey = "start"
+  val endKey = "end"
+  val defaultKey = "default"
+}

--- a/test/views/components/ErrorSummarySpec.scala
+++ b/test/views/components/ErrorSummarySpec.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components
+
+import helpers.FormHelper.updateFormErrorKeyForStartAndEndDate
+import org.mockito.MockitoSugar.mock
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import play.api.data.FormError
+import play.api.i18n.Messages
+import play.api.test.Helpers
+import play.api.{Application, inject}
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.html.components.GovukErrorSummary
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+import uk.gov.hmrc.govukfrontend.views.viewmodels.errorsummary.{ErrorLink, ErrorSummary}
+import utils.SpecBase
+import views.html.components.errorSummary
+
+class ErrorSummarySpec extends SpecBase {
+  "ErrorSummary component" must {
+    "show correct error with unchanged key when isErrorKeyUpdateEnabled is false" in new SetUp {
+      val errorSum: ErrorSummary = ErrorSummary(
+        errorList = Seq(ErrorLink(Some("#start"), content = Text(msgs("cf.form.error.start.date-number-invalid")))),
+        title = Text(msgs("error.summary.title"))
+      )
+
+      val govSummaryHtmlFormat: HtmlFormat.Appendable = new GovukErrorSummary().apply(errorSum)
+
+      when(mockGovSummary.apply(any[ErrorSummary])).thenReturn(govSummaryHtmlFormat)
+
+      val app: Application = application.overrides(
+        inject.bind[GovukErrorSummary].toInstance(mockGovSummary)
+      ).build()
+
+      val view: errorSummary = app.injector.instanceOf[errorSummary]
+      val formErrors: Seq[FormError] = Seq(FormError("start", "cf.form.error.start.date-number-invalid"))
+
+      val result: HtmlFormat.Appendable = view(formErrors, None)
+
+      result.toString().contains(
+        "<a href=\"#start\">cf.form.error.start.date-number-invalid</a>") shouldBe true
+      result.toString().contains("error.summary.title") shouldBe true
+    }
+
+    "show correct error with updated key when key has value start, isErrorKeyUpdateEnabled is true and " +
+      "updateFormErrorKeyForTheMessage function is provided" in new SetUp {
+
+      val errorSum: ErrorSummary = ErrorSummary(
+        errorList = Seq(ErrorLink(Some("#start.day"), content = Text(msgs("cf.form.error.start-future-date")))),
+        title = Text(msgs("error.summary.title"))
+      )
+
+      val govSummaryHtmlFormat: HtmlFormat.Appendable = new GovukErrorSummary().apply(errorSum)
+
+      when(mockGovSummary.apply(any[ErrorSummary])).thenReturn(govSummaryHtmlFormat)
+
+      val app: Application = application.overrides(
+        inject.bind[GovukErrorSummary].toInstance(mockGovSummary)
+      ).build()
+
+      val view: errorSummary = app.injector.instanceOf[errorSummary]
+      val formErrors: Seq[FormError] = Seq(FormError("start", "cf.form.error.start-future-date"))
+
+      val result: HtmlFormat.Appendable = view(
+        formErrors,
+        None,
+        isErrorKeyUpdateEnabled = true,
+        updateFormErrorKeyForTheMessage = Some(updateFormErrorKeyForStartAndEndDate()))
+
+      result.toString().contains(
+        "<a href=\"#start.day\">cf.form.error.start-future-date</a>") shouldBe true
+      result.toString().contains("error.summary.title") shouldBe true
+    }
+
+    "show correct error with updated key when key has value start,error msg key is cf.form.error.year.length " +
+      " isErrorKeyUpdateEnabled is true and updateFormErrorKeyForTheMessage function is provided" in new SetUp {
+
+      val errorSum: ErrorSummary = ErrorSummary(
+        errorList = Seq(ErrorLink(Some("#start.year"), content = Text(msgs("cf.form.error.year.length")))),
+        title = Text(msgs("error.summary.title"))
+      )
+
+      val govSummaryHtmlFormat: HtmlFormat.Appendable = new GovukErrorSummary().apply(errorSum)
+
+      when(mockGovSummary.apply(any[ErrorSummary])).thenReturn(govSummaryHtmlFormat)
+
+      val app: Application = application.overrides(
+        inject.bind[GovukErrorSummary].toInstance(mockGovSummary)
+      ).build()
+
+      val view: errorSummary = app.injector.instanceOf[errorSummary]
+      val formErrors: Seq[FormError] = Seq(FormError("start", "cf.form.error.year.length"))
+
+      val result: HtmlFormat.Appendable = view(
+        formErrors,
+        None,
+        isErrorKeyUpdateEnabled = true,
+        updateFormErrorKeyForTheMessage = Some(updateFormErrorKeyForStartAndEndDate()))
+
+      result.toString().contains(
+        "<a href=\"#start.year\">cf.form.error.year.length</a>") shouldBe true
+      result.toString().contains("error.summary.title") shouldBe true
+    }
+
+    "show correct error with updated key when key has value of end, isErrorKeyUpdateEnabled is true and " +
+      "updateFormErrorKeyForTheMessage function is provided" in new SetUp {
+
+      val errorSum: ErrorSummary = ErrorSummary(
+        errorList = Seq(ErrorLink(Some("#end.day"), content = Text(msgs("cf.form.error.end-future-date")))),
+        title = Text(msgs("error.summary.title"))
+      )
+
+      val govSummaryHtmlFormat: HtmlFormat.Appendable = new GovukErrorSummary().apply(errorSum)
+
+      when(mockGovSummary.apply(any[ErrorSummary])).thenReturn(govSummaryHtmlFormat)
+
+      val app: Application = application.overrides(
+        inject.bind[GovukErrorSummary].toInstance(mockGovSummary)
+      ).build()
+
+      val view: errorSummary = app.injector.instanceOf[errorSummary]
+      val formErrors: Seq[FormError] = Seq(FormError("end", "cf.form.error.end-future-date"))
+
+      val result: HtmlFormat.Appendable = view(
+        formErrors,
+        None,
+        isErrorKeyUpdateEnabled = true,
+        updateFormErrorKeyForTheMessage = Some(updateFormErrorKeyForStartAndEndDate()))
+
+      result.toString().contains(
+        "<a href=\"#end.day\">cf.form.error.end-future-date</a>") shouldBe true
+      result.toString().contains("error.summary.title") shouldBe true
+    }
+
+    "show correct error with updated key when key has value end,error msg key is cf.form.error.year.length " +
+      " isErrorKeyUpdateEnabled is true and updateFormErrorKeyForTheMessage function is provided" in new SetUp {
+
+      val errorSum: ErrorSummary = ErrorSummary(
+        errorList = Seq(ErrorLink(Some("#end.year"), content = Text(msgs("cf.form.error.year.length")))),
+        title = Text(msgs("error.summary.title"))
+      )
+
+      val govSummaryHtmlFormat: HtmlFormat.Appendable = new GovukErrorSummary().apply(errorSum)
+
+      when(mockGovSummary.apply(any[ErrorSummary])).thenReturn(govSummaryHtmlFormat)
+
+      val app: Application = application.overrides(
+        inject.bind[GovukErrorSummary].toInstance(mockGovSummary)
+      ).build()
+
+      val view: errorSummary = app.injector.instanceOf[errorSummary]
+      val formErrors: Seq[FormError] = Seq(FormError("end", "cf.form.error.year.length"))
+
+      val result: HtmlFormat.Appendable = view(
+        formErrors,
+        None,
+        isErrorKeyUpdateEnabled = true,
+        updateFormErrorKeyForTheMessage = Some(updateFormErrorKeyForStartAndEndDate()))
+
+      result.toString().contains(
+        "<a href=\"#end.year\">cf.form.error.year.length</a>") shouldBe true
+      result.toString().contains("error.summary.title") shouldBe true
+    }
+  }
+}
+
+trait SetUp {
+  implicit val msgs: Messages = Helpers.stubMessages()
+  val mockGovSummary: GovukErrorSummary = mock[GovukErrorSummary]
+}


### PR DESCRIPTION
Description - Changes are done to direct the error hyperlink to point to the correct input field for both start and end date
                        in case of form errors

Below have been done as part of these changes

- ErrorSummary component has been updated to point to the correct FormError key and default key (was to the month field ) has ben removed
- Code has been added to update the FormError keys in different errors in order to refer to the correct input field
- Couple of helpers have been added
- Minor refactoring has been done