### PR TITLE
[MMCA - 4791] - Use of customs-data-store routes for email address retrieval

### DIFF
--- a/app/connectors/CustomsDataStoreConnector.scala
+++ b/app/connectors/CustomsDataStoreConnector.scala
@@ -64,21 +64,27 @@ class CustomsDataStoreConnector @Inject()(httpClient: HttpClientV2,
   def verifiedEmail(implicit hc: HeaderCarrier): Future[EmailVerifiedResponse] = {
     val emailDisplayApiUrl = s"${appConfig.customsDataStore}/subscriptions/email-display"
 
-    httpClient.get(url"$emailDisplayApiUrl").execute[EmailVerifiedResponse].recover {
-      case _ =>
-        log.error(s"Error occurred while calling API $emailDisplayApiUrl")
-        EmailVerifiedResponse(None)
-    }
+    httpClient
+      .get(url"$emailDisplayApiUrl")
+      .execute[EmailVerifiedResponse]
+      .recover {
+        case _ =>
+          log.error(s"Error occurred while calling API $emailDisplayApiUrl")
+          EmailVerifiedResponse(None)
+      }
   }
 
   def retrieveUnverifiedEmail(implicit hc: HeaderCarrier): Future[EmailUnverifiedResponse] = {
     val unverifiedEmailDisplayApiUrl = s"${appConfig.customsDataStore}/subscriptions/unverified-email-display"
 
-    httpClient.get(url"$unverifiedEmailDisplayApiUrl").execute[EmailUnverifiedResponse].recover {
-      case _ =>
-        log.error(s"Error occurred while calling API $unverifiedEmailDisplayApiUrl")
-        EmailUnverifiedResponse(None)
-    }
+    httpClient
+      .get(url"$unverifiedEmailDisplayApiUrl")
+      .execute[EmailUnverifiedResponse]
+      .recover {
+        case _ =>
+          log.error(s"Error occurred while calling API $unverifiedEmailDisplayApiUrl")
+          EmailUnverifiedResponse(None)
+      }
   }
 
 }

--- a/app/connectors/CustomsFinancialsApiConnector.scala
+++ b/app/connectors/CustomsFinancialsApiConnector.scala
@@ -19,7 +19,6 @@ package connectors
 import config.AppConfig
 import models.CashDailyStatement.*
 import models.*
-import models.email.{EmailUnverifiedResponse, EmailVerifiedResponse}
 import models.request.{CashDailyStatementRequest, IdentifierRequest}
 import org.slf4j.LoggerFactory
 import play.api.http.Status.{NOT_FOUND, REQUEST_ENTITY_TOO_LARGE}
@@ -144,26 +143,6 @@ class CustomsFinancialsApiConnector @Inject()(httpClient: HttpClientV2,
     case e =>
       logger.error(s"Unable to download CSV :${e.getMessage}")
       Left(UnknownException)
-  }
-
-  def verifiedEmail(implicit hc: HeaderCarrier): Future[EmailVerifiedResponse] = {
-    val emailDisplayApiUrl = s"$baseUrl/subscriptions/email-display"
-
-    httpClient.get(url"$emailDisplayApiUrl").execute[EmailVerifiedResponse].recover {
-      case _ =>
-        logger.error(s"Error occurred while calling API $emailDisplayApiUrl")
-        EmailVerifiedResponse(None)
-    }
-  }
-
-  def retrieveUnverifiedEmail(implicit hc: HeaderCarrier): Future[EmailUnverifiedResponse] = {
-    val unverifiedEmailDisplayApiUrl = s"$baseUrl/subscriptions/unverified-email-display"
-
-    httpClient.get(url"$unverifiedEmailDisplayApiUrl").execute[EmailUnverifiedResponse].recover {
-      case _ =>
-        logger.error(s"Error occurred while calling API $unverifiedEmailDisplayApiUrl")
-        EmailUnverifiedResponse(None)
-    }
   }
 }
 

--- a/app/controllers/EmailController.scala
+++ b/app/controllers/EmailController.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import config.AppConfig
-import connectors.CustomsFinancialsApiConnector
+import connectors.CustomsDataStoreConnector
 import controllers.actions.IdentifierAction
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -30,19 +30,20 @@ import scala.concurrent.ExecutionContext
 class EmailController @Inject()(authenticate: IdentifierAction,
                                 verifyEmailView: verify_your_email,
                                 undeliverableEmailView: undeliverable_email,
-                                financialsApiConnector: CustomsFinancialsApiConnector
+                                dataStoreConnector: CustomsDataStoreConnector
                                )(implicit mcc: MessagesControllerComponents, ec: ExecutionContext, appConfig: AppConfig)
-  extends FrontendController(mcc) with I18nSupport {
+  extends FrontendController(mcc)
+    with I18nSupport {
 
   def showUnverified(): Action[AnyContent] = authenticate async { implicit request =>
-    financialsApiConnector.retrieveUnverifiedEmail.map(
+    dataStoreConnector.retrieveUnverifiedEmail.map(
       emailUnverifiedRes => Ok(verifyEmailView(appConfig.emailFrontendUrl, emailUnverifiedRes.unVerifiedEmail))
     )
   }
 
   def showUndeliverable(): Action[AnyContent] = authenticate async {
     implicit request =>
-      financialsApiConnector.verifiedEmail.map {
+      dataStoreConnector.verifiedEmail.map {
         emailVerifiedRes => Ok(undeliverableEmailView(appConfig.emailFrontendUrl, emailVerifiedRes.verifiedEmail))
       }
   }

--- a/test/connectors/CustomsFinancialsApiConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsApiConnectorSpec.scala
@@ -26,7 +26,7 @@ import play.api.inject.bind
 import play.api.test.Helpers.*
 import repositories.CacheRepository
 import services.MetricsReporterService
-import uk.gov.hmrc.http.{HeaderCarrier, HttpException, HttpReads, InternalServerException, SessionId, UpstreamErrorResponse}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpException, HttpReads, SessionId, UpstreamErrorResponse}
 import utils.SpecBase
 import java.net.URL
 

--- a/test/connectors/CustomsFinancialsApiConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsApiConnectorSpec.scala
@@ -450,9 +450,6 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
             LocalDate.parse("2020-07-20"), -30.00, Nil)), Nil)
     )
 
-    val customFinancialsApiUrl = "http://localhost:9878/customs-financials-api/subscriptions/unverified-email-display"
-    val verifyEmailApiUrl = "http://localhost:9878/customs-financials-api/subscriptions/email-display"
-
     val appWithHttpClient: Application = application
       .overrides(
         bind[HttpClientV2].toInstance(mockHttpClient),

--- a/test/connectors/CustomsFinancialsApiConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsApiConnectorSpec.scala
@@ -18,7 +18,6 @@ package connectors
 
 import config.AppConfig
 import models.*
-import models.email.{EmailUnverifiedResponse, EmailVerifiedResponse}
 import models.request.{CashDailyStatementRequest, IdentifierRequest}
 import org.mockito.ArgumentMatchers.anyString
 import play.api.{Application, inject}
@@ -383,55 +382,6 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
   }
 
-  "retrieveUnverifiedEmail" must {
-    "return EmailUnverifiedResponse with unverified email value" in new Setup {
-
-      when(requestBuilder.execute(any[HttpReads[EmailUnverifiedResponse]], any[ExecutionContext]))
-        .thenReturn(Future.successful(emailUnverifiedRes))
-      when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
-
-      connector().retrieveUnverifiedEmail.map {
-        _ mustBe emailUnverifiedRes
-      }
-    }
-
-    "return EmailUnverifiedResponse with None for unverified email if there is an error while" +
-      " fetching response from api" in new Setup {
-
-      when(requestBuilder.execute(any[HttpReads[EmailUnverifiedResponse]], any[ExecutionContext]))
-        .thenReturn(Future.failed(new RuntimeException("error occurred")))
-      when(mockHttpClient.get(any())(any())).thenReturn(requestBuilder)
-
-      connector().retrieveUnverifiedEmail.map {
-        _.unVerifiedEmail mustBe empty
-      }
-    }
-  }
-
-  "verifiedEmail" must {
-    "return verified email when email-display api call is successful" in new Setup {
-
-      when(requestBuilder.execute(any[HttpReads[EmailVerifiedResponse]], any[ExecutionContext]))
-        .thenReturn(Future.successful(emailVerifiedRes))
-      when(mockHttpClient.get(any())(any())).thenReturn(requestBuilder)
-
-      connector().verifiedEmail.map {
-        _ mustBe emailVerifiedRes
-      }
-    }
-
-    "return none for verified email when exception occurs while calling email-display api" in new Setup {
-
-      when(requestBuilder.execute(any[HttpReads[EmailVerifiedResponse]], any[ExecutionContext]))
-        .thenReturn(Future.failed(new InternalServerException("error occurred")))
-      when(mockHttpClient.get(any())(any())).thenReturn(requestBuilder)
-
-      connector().verifiedEmail.map {
-        _.verifiedEmail mustBe empty
-      }
-    }
-  }
-
   trait Setup {
     private val traderEori = "12345678"
     private val cashAccountNumber = "987654"
@@ -499,10 +449,6 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
           Declaration("mrn4", Some("Importer EORI"), "Declarant EORI", Some("Declarant Reference"),
             LocalDate.parse("2020-07-20"), -30.00, Nil)), Nil)
     )
-
-    val emailId = "test@test.com"
-    val emailUnverifiedRes: EmailUnverifiedResponse = EmailUnverifiedResponse(Some(emailId))
-    val emailVerifiedRes: EmailVerifiedResponse = EmailVerifiedResponse(Some(emailId))
 
     val customFinancialsApiUrl = "http://localhost:9878/customs-financials-api/subscriptions/unverified-email-display"
     val verifyEmailApiUrl = "http://localhost:9878/customs-financials-api/subscriptions/email-display"

--- a/test/connectors/DataStoreConnectorSpec.scala
+++ b/test/connectors/DataStoreConnectorSpec.scala
@@ -22,7 +22,7 @@ import play.api.Application
 import play.api.inject.bind
 import services.MetricsReporterService
 import uk.gov.hmrc.auth.core.retrieve.Email
-import uk.gov.hmrc.http.HttpReads
+import uk.gov.hmrc.http.{HttpReads, InternalServerException}
 import utils.SpecBase
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -30,6 +30,9 @@ import scala.concurrent.Future
 import org.mockito.Mockito.when
 import org.mockito.ArgumentMatchers.any
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
+import models.email.{EmailUnverifiedResponse, EmailVerifiedResponse}
+
+import java.net.URL
 import scala.concurrent.ExecutionContext
 
 class DataStoreConnectorSpec extends SpecBase {
@@ -97,10 +100,62 @@ class DataStoreConnectorSpec extends SpecBase {
     }
   }
 
+  "retrieveUnverifiedEmail" must {
+    "return EmailUnverifiedResponse with unverified email value" in new Setup {
+
+      when(requestBuilder.execute(any[HttpReads[EmailUnverifiedResponse]], any[ExecutionContext]))
+        .thenReturn(Future.successful(emailUnverifiedRes))
+      when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
+
+      connector.retrieveUnverifiedEmail.map {
+        _ mustBe emailUnverifiedRes
+      }
+    }
+
+    "return EmailUnverifiedResponse with None for unverified email if there is an error while" +
+      " fetching response from api" in new Setup {
+
+      when(requestBuilder.execute(any[HttpReads[EmailUnverifiedResponse]], any[ExecutionContext]))
+        .thenReturn(Future.failed(new RuntimeException("error occurred")))
+      when(mockHttpClient.get(any())(any())).thenReturn(requestBuilder)
+
+      connector.retrieveUnverifiedEmail.map {
+        _.unVerifiedEmail mustBe empty
+      }
+    }
+  }
+
+  "verifiedEmail" must {
+    "return verified email when email-display api call is successful" in new Setup {
+
+      when(requestBuilder.execute(any[HttpReads[EmailVerifiedResponse]], any[ExecutionContext]))
+        .thenReturn(Future.successful(emailVerifiedRes))
+      when(mockHttpClient.get(any())(any())).thenReturn(requestBuilder)
+
+      connector.verifiedEmail.map {
+        _ mustBe emailVerifiedRes
+      }
+    }
+
+    "return none for verified email when exception occurs while calling email-display api" in new Setup {
+
+      when(requestBuilder.execute(any[HttpReads[EmailVerifiedResponse]], any[ExecutionContext]))
+        .thenReturn(Future.failed(new InternalServerException("error occurred")))
+      when(mockHttpClient.get(any())(any())).thenReturn(requestBuilder)
+
+      connector.verifiedEmail.map {
+        _.verifiedEmail mustBe empty
+      }
+    }
+  }
+
   trait Setup {
     val eori = "EORINOTIMESTAMP"
     val emailId = "test@test.com"
     val value = 12
+
+    val emailUnverifiedRes: EmailUnverifiedResponse = EmailUnverifiedResponse(Some(emailId))
+    val emailVerifiedRes: EmailVerifiedResponse = EmailVerifiedResponse(Some(emailId))
 
     val undelInfoEventOb: UndeliverableInformationEvent = UndeliverableInformationEvent("example-id",
       "someEvent",

--- a/test/connectors/DataStoreConnectorSpec.scala
+++ b/test/connectors/DataStoreConnectorSpec.scala
@@ -62,6 +62,7 @@ class DataStoreConnectorSpec extends SpecBase {
 
       when(requestBuilder.execute(any[HttpReads[EmailResponse]], any[ExecutionContext]))
         .thenReturn(Future.successful(emailResFromAPI))
+
       when(mockHttpClient.get(any())(any())).thenReturn(requestBuilder)
 
       connector.getEmail(eori).map {
@@ -72,11 +73,12 @@ class DataStoreConnectorSpec extends SpecBase {
     "return Left(UnverifiedEmail) when unverified email is returned from data store" in new Setup {
       val emailResFromAPI: EmailResponse = EmailResponse(None, None, Some(undelInfoOb))
 
-      when(mockMetricsReporter.withResponseTimeLogging[EmailResponse](any)(any)(any)).thenReturn(
-        Future.successful(emailResFromAPI))
+      when(mockMetricsReporter.withResponseTimeLogging[EmailResponse](any)(any)(any))
+        .thenReturn(Future.successful(emailResFromAPI))
 
       when(requestBuilder.execute(any[HttpReads[EmailResponse]], any[ExecutionContext]))
         .thenReturn(Future.successful(emailResFromAPI))
+
       when(mockHttpClient.get(any())(any())).thenReturn(requestBuilder)
 
       connector.getEmail(eori).map {
@@ -87,11 +89,12 @@ class DataStoreConnectorSpec extends SpecBase {
     "return Left(UnverifiedEmail) if any error occurs while calling the data store API " in new Setup {
       private val emailResFromAPI = EmailResponse(Some(emailId), None, None)
 
-      when(mockMetricsReporter.withResponseTimeLogging[EmailResponse](any)(any)(any)).thenReturn(
-        Future.successful(emailResFromAPI))
+      when(mockMetricsReporter.withResponseTimeLogging[EmailResponse](any)(any)(any))
+        .thenReturn(Future.successful(emailResFromAPI))
 
       when(requestBuilder.execute(any[HttpReads[EmailResponse]], any[ExecutionContext]))
         .thenReturn(Future.failed(new RuntimeException("Error occurred")))
+
       when(mockHttpClient.get(any())(any())).thenReturn(requestBuilder)
 
       connector.getEmail(eori).map {
@@ -105,6 +108,7 @@ class DataStoreConnectorSpec extends SpecBase {
 
       when(requestBuilder.execute(any[HttpReads[EmailUnverifiedResponse]], any[ExecutionContext]))
         .thenReturn(Future.successful(emailUnverifiedRes))
+
       when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
 
       connector.retrieveUnverifiedEmail.map {
@@ -117,6 +121,7 @@ class DataStoreConnectorSpec extends SpecBase {
 
       when(requestBuilder.execute(any[HttpReads[EmailUnverifiedResponse]], any[ExecutionContext]))
         .thenReturn(Future.failed(new RuntimeException("error occurred")))
+
       when(mockHttpClient.get(any())(any())).thenReturn(requestBuilder)
 
       connector.retrieveUnverifiedEmail.map {
@@ -130,6 +135,7 @@ class DataStoreConnectorSpec extends SpecBase {
 
       when(requestBuilder.execute(any[HttpReads[EmailVerifiedResponse]], any[ExecutionContext]))
         .thenReturn(Future.successful(emailVerifiedRes))
+
       when(mockHttpClient.get(any())(any())).thenReturn(requestBuilder)
 
       connector.verifiedEmail.map {
@@ -141,6 +147,7 @@ class DataStoreConnectorSpec extends SpecBase {
 
       when(requestBuilder.execute(any[HttpReads[EmailVerifiedResponse]], any[ExecutionContext]))
         .thenReturn(Future.failed(new InternalServerException("error occurred")))
+
       when(mockHttpClient.get(any())(any())).thenReturn(requestBuilder)
 
       connector.verifiedEmail.map {

--- a/test/controllers/EmailControllerSpec.scala
+++ b/test/controllers/EmailControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import connectors.CustomsFinancialsApiConnector
+import connectors.CustomsDataStoreConnector
 import models.email.{EmailUnverifiedResponse, EmailVerifiedResponse}
 import play.api.Application
 import play.api.http.Status.OK
@@ -63,7 +63,7 @@ class EmailControllerSpec extends SpecBase {
 
   trait Setup {
     implicit val hc: HeaderCarrier = HeaderCarrier()
-    val mockConnector: CustomsFinancialsApiConnector = mock[CustomsFinancialsApiConnector]
+    val mockConnector: CustomsDataStoreConnector = mock[CustomsDataStoreConnector]
 
     val emailId = "test@test.com"
     val emailVerifiedResponse: EmailVerifiedResponse = EmailVerifiedResponse(Some(emailId))
@@ -71,7 +71,7 @@ class EmailControllerSpec extends SpecBase {
 
     val app: Application = application
       .overrides(
-        bind[CustomsFinancialsApiConnector].toInstance(mockConnector)
+        bind[CustomsDataStoreConnector].toInstance(mockConnector)
       ).build()
   }
 }

--- a/test/controllers/EmailControllerSpec.scala
+++ b/test/controllers/EmailControllerSpec.scala
@@ -45,12 +45,36 @@ class EmailControllerSpec extends SpecBase {
         status(result) mustBe OK
       }
     }
+
+    "display verify your email page when exception occurs while connector making the API call" in new Setup {
+
+      when(mockConnector.retrieveUnverifiedEmail(any))
+        .thenReturn(Future.successful(emailUnverifiedResponseWithNoEmailId))
+
+      running(app) {
+        val request = fakeRequest(GET, routes.EmailController.showUnverified().url)
+
+        val result = route(app, request).value
+        status(result) mustBe OK
+      }
+    }
   }
 
   "showUndeliverable" must {
 
     "display undeliverableEmail page" in new Setup {
       when(mockConnector.verifiedEmail(any)).thenReturn(Future.successful(emailVerifiedResponse))
+
+      running(app) {
+        val request = fakeRequest(GET, routes.EmailController.showUndeliverable().url)
+        val result = route(app, request).value
+
+        status(result) mustBe OK
+      }
+    }
+
+    "display undeliverableEmail page when exception occurs while connector is making the API call" in new Setup {
+      when(mockConnector.verifiedEmail(any)).thenReturn(Future.successful(emailVerifiedResponseWithNoEmailId))
 
       running(app) {
         val request = fakeRequest(GET, routes.EmailController.showUndeliverable().url)
@@ -67,7 +91,10 @@ class EmailControllerSpec extends SpecBase {
 
     val emailId = "test@test.com"
     val emailVerifiedResponse: EmailVerifiedResponse = EmailVerifiedResponse(Some(emailId))
+    val emailVerifiedResponseWithNoEmailId: EmailVerifiedResponse = EmailVerifiedResponse(None)
+
     val emailUnverifiedResponse: EmailUnverifiedResponse = EmailUnverifiedResponse(Some(emailId))
+    val emailUnverifiedResponseWithNoEmailId: EmailUnverifiedResponse = EmailUnverifiedResponse(None)
 
     val app: Application = application
       .overrides(

--- a/test/controllers/EmailControllerSpec.scala
+++ b/test/controllers/EmailControllerSpec.scala
@@ -63,6 +63,7 @@ class EmailControllerSpec extends SpecBase {
   "showUndeliverable" must {
 
     "display undeliverableEmail page" in new Setup {
+
       when(mockConnector.verifiedEmail(any)).thenReturn(Future.successful(emailVerifiedResponse))
 
       running(app) {
@@ -74,6 +75,7 @@ class EmailControllerSpec extends SpecBase {
     }
 
     "display undeliverableEmail page when exception occurs while connector is making the API call" in new Setup {
+
       when(mockConnector.verifiedEmail(any)).thenReturn(Future.successful(emailVerifiedResponseWithNoEmailId))
 
       running(app) {


### PR DESCRIPTION
Description - Make use of email retrieval endpoints from DataStore instead of using financials api

Below has been done as part of this PR

- use of email retrieval endpoints from DataStore
- move the email retrieval methods from API connector to DataStore connector
- move tests
- add new tests
- minor refactoring