### PR TITLE
MMCA-4898 | Display MRN details on click of MRN hyperlink from the Cash Account Transactions List

### DIFF
--- a/app/connectors/CustomsFinancialsApiConnector.scala
+++ b/app/connectors/CustomsFinancialsApiConnector.scala
@@ -92,7 +92,7 @@ class CustomsFinancialsApiConnector @Inject()(httpClient: HttpClientV2,
                               (implicit hc: HeaderCarrier): Future[Either[ErrorResponse, CashTransactions]] = {
     val cashDailyStatementRequest = CashDailyStatementRequest(can, from, to)
 
-    def addUUID(response: CashTransactions): CashTransactions = {
+    def addUUIDToCashTransaction(response: CashTransactions): CashTransactions = {
       response.copy(
         cashDailyStatements = response.cashDailyStatements.map { statement =>
           statement.copy(
@@ -112,11 +112,13 @@ class CustomsFinancialsApiConnector @Inject()(httpClient: HttpClientV2,
           .withBody[CashDailyStatementRequest](cashDailyStatementRequest)
           .execute[CashTransactions]
           .flatMap { response =>
-            val transactionsWithUUID = addUUID(response)
+            val transactionsWithUUID = addUUIDToCashTransaction(response)
+
             cacheRepository.set(can, transactionsWithUUID).map { successfulWrite =>
               if (!successfulWrite) {
                 logger.error("Failed to store data in the session cache defaulting to the api response")
               }
+
               Right(transactionsWithUUID)
             }
           }

--- a/app/connectors/CustomsFinancialsApiConnector.scala
+++ b/app/connectors/CustomsFinancialsApiConnector.scala
@@ -39,8 +39,7 @@ import java.util.UUID
 class CustomsFinancialsApiConnector @Inject()(httpClient: HttpClientV2,
                                               appConfig: AppConfig,
                                               metricsReporter: MetricsReporterService,
-                                              cacheRepository: CacheRepository,
-                                              loggerFactory: LoggerFactory)
+                                              cacheRepository: CacheRepository)
                                              (implicit executionContext: ExecutionContext) {
 
   private val logger = LoggerFactory.getLogger("application." + getClass.getCanonicalName)

--- a/app/controllers/DeclarationDetailController.scala
+++ b/app/controllers/DeclarationDetailController.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.{AppConfig, ErrorHandler}
+import connectors.CustomsFinancialsApiConnector
+import controllers.actions.{EmailAction, IdentifierAction}
+import helpers.CashAccountUtils
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import views.html.{cash_account_declaration_details, cash_transactions_no_result}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+import play.api.Logging
+import viewmodels.{DeclarationDetailViewModel, ResultsPageSummary}
+
+class DeclarationDetailController @Inject()(authenticate: IdentifierAction,
+                                            verifyEmail: EmailAction,
+                                            apiConnector: CustomsFinancialsApiConnector,
+                                            errorHandler: ErrorHandler,
+                                            mcc: MessagesControllerComponents,
+                                            view: cash_account_declaration_details,
+                                            cashAccountUtils: CashAccountUtils,
+                                            noTransactions: cash_transactions_no_result
+                                           )(implicit executionContext: ExecutionContext,
+                                             val appConfig: AppConfig
+                                           ) extends FrontendController(mcc) with I18nSupport with Logging {
+
+  def displayDetails(ref: String, page: Option[Int]): Action[AnyContent] =
+    (authenticate andThen verifyEmail).async { implicit request =>
+
+      apiConnector.getCashAccount(request.eori).flatMap {
+        case Some(account) => val (from, to) = cashAccountUtils.transactionDateRange()
+
+          apiConnector.retrieveCashTransactions(account.number, from, to).map {
+            case Right(transactions) =>
+              transactions.cashDailyStatements
+                .flatMap(_.declarations)
+                .find(_.secureMovementReferenceNumber.contains(ref))
+                .map(declaration => Ok(view(DeclarationDetailViewModel(request.eori, account), declaration, page)))
+                .getOrElse(NotFound(errorHandler.notFoundTemplate))
+
+            case Left(_) => Ok(noTransactions(new ResultsPageSummary(from, to)))
+          }
+
+        case None => Future.successful(NotFound(errorHandler.notFoundTemplate))
+      }
+    }
+}

--- a/app/crypto/CashTransactionsEncrypter.scala
+++ b/app/crypto/CashTransactionsEncrypter.scala
@@ -16,9 +16,10 @@
 
 package crypto
 
-import models._
+import models.*
 import utils.Utils.emptyString
 
+import java.util.UUID
 import javax.inject.Inject
 
 class CashTransactionsEncrypter @Inject()(crypto: AesGCMCrypto) {
@@ -69,7 +70,8 @@ class CashTransactionsEncrypter @Inject()(crypto: AesGCMCrypto) {
       declaration.declarantReference.map(encrypt),
       declaration.date,
       declaration.amount,
-      declaration.taxGroups
+      declaration.taxGroups,
+      declaration.secureMovementReferenceNumber.getOrElse(UUID.randomUUID().toString)
     )
   }
 
@@ -86,7 +88,8 @@ class CashTransactionsEncrypter @Inject()(crypto: AesGCMCrypto) {
       encryptedDeclaration.declarantReference.map(decrypt),
       encryptedDeclaration.date,
       encryptedDeclaration.amount,
-      encryptedDeclaration.taxGroups
+      encryptedDeclaration.taxGroups,
+      Some(encryptedDeclaration.secureMovementReferenceNumber)
     )
   }
 }

--- a/app/helpers/Formatters.scala
+++ b/app/helpers/Formatters.scala
@@ -53,6 +53,6 @@ object Formatters {
 
     numberFormat.setMaximumFractionDigits(maxDecimalPlaces)
     numberFormat.setMinimumFractionDigits(maxDecimalPlaces)
-    numberFormat.format(amount.abs)
+    numberFormat.format(amount)
   }
 }

--- a/app/models/Declaration.scala
+++ b/app/models/Declaration.scala
@@ -17,7 +17,7 @@
 package models
 
 import crypto.EncryptedValue
-import models.domain.{EORI, MRN}
+import models.domain.{EORI, MRN, UCR}
 import play.api.libs.json.{Json, OFormat}
 
 import java.time.LocalDate
@@ -25,10 +25,11 @@ import java.time.LocalDate
 case class Declaration(movementReferenceNumber: MRN,
                        importerEori: Option[String],
                        declarantEori: EORI,
-                       declarantReference: Option[String],
+                       declarantReference: Option[UCR],
                        date: LocalDate,
                        amount: BigDecimal,
-                       taxGroups: Seq[TaxGroup])
+                       taxGroups: Seq[TaxGroup],
+                       secureMovementReferenceNumber: Option[String])
   extends Ordered[Declaration] {
   override def compare(that: Declaration): Int = movementReferenceNumber.compareTo(that.movementReferenceNumber)
 }
@@ -43,7 +44,8 @@ case class EncryptedDeclaration(movementReferenceNumber: EncryptedValue,
                                 declarantReference: Option[EncryptedValue],
                                 date: LocalDate,
                                 amount: BigDecimal,
-                                taxGroups: Seq[TaxGroup])
+                                taxGroups: Seq[TaxGroup],
+                                secureMovementReferenceNumber: String)
 
 object EncryptedDeclaration {
   implicit val format: OFormat[EncryptedDeclaration] = Json.format[EncryptedDeclaration]

--- a/app/models/TaxGroup.scala
+++ b/app/models/TaxGroup.scala
@@ -18,7 +18,13 @@ package models
 
 import play.api.libs.json.{Json, OFormat}
 
-case class TaxGroup(taxTypeGroup: TaxGroupType, amount: BigDecimal)
+case class TaxGroup(taxGroupDescription: TaxGroupType, amount: BigDecimal, taxTypes: Seq[TaxType])
+
+case class TaxType(reasonForSecurity: String, taxTypeID: String, amount: BigDecimal)
+
+object TaxType {
+  implicit val format: OFormat[TaxType] = Json.format[TaxType]
+}
 
 object TaxGroup {
   implicit val format: OFormat[TaxGroup] = Json.format[TaxGroup]

--- a/app/models/domain.scala
+++ b/app/models/domain.scala
@@ -24,6 +24,7 @@ package object domain {
   type LinkId = String
   type CAN = String
   type MRN = String
+  type UCR = String
 
   implicit def optionBindable: PathBindable[Option[LinkId]] = new PathBindable[Option[LinkId]] {
 

--- a/app/viewmodels/CashTransactionCsvRow.scala
+++ b/app/viewmodels/CashTransactionCsvRow.scala
@@ -87,7 +87,7 @@ object CashTransactionCsvRow {
     }
 
     private def findTaxGroups(taxGroupType: TaxGroupType, groups: Seq[TaxGroup]): Option[BigDecimal] = {
-      groups.find(_.taxTypeGroup == taxGroupType).map(_.amount.abs).orElse(Some(BigDecimal(0)))
+      groups.find(_.taxGroupDescription == taxGroupType).map(_.amount.abs).orElse(Some(BigDecimal(0)))
     }
 
     val withdrawals: Seq[CashTransactionCsvRow] = cashDailyStatement.withdrawals.map { withdrawal =>

--- a/app/viewmodels/DeclarationDetailViewModel.scala
+++ b/app/viewmodels/DeclarationDetailViewModel.scala
@@ -86,9 +86,9 @@ object DeclarationDetailViewModel {
         SummaryListRow(
           key = Key(content = Text(messages("cf.cash-account.csv.excise"))),
           value = Value(content = HtmlContent(
-            Formatters.formatCurrencyAmount(declaration.taxGroups.find(_.taxTypeGroup == ExciseDuty)
+            declaration.taxGroups.find(_.taxTypeGroup == ExciseDuty)
               .map(_.amount)
-              .getOrElse(BigDecimal(0)))
+              .fold(emptyString)(amount => Formatters.formatCurrencyAmount(amount))
           )),
           actions = None
         ),

--- a/app/viewmodels/DeclarationDetailViewModel.scala
+++ b/app/viewmodels/DeclarationDetailViewModel.scala
@@ -68,7 +68,7 @@ object DeclarationDetailViewModel {
         SummaryListRow(
           key = Key(content = Text(messages("cf.cash-account.csv.duty"))),
           value = Value(content = HtmlContent(
-            Formatters.formatCurrencyAmount(declaration.taxGroups.find(_.taxTypeGroup == CustomsDuty)
+            Formatters.formatCurrencyAmount(declaration.taxGroups.find(_.taxGroupDescription == CustomsDuty)
               .map(_.amount)
               .getOrElse(BigDecimal(0)))
           )),
@@ -77,7 +77,7 @@ object DeclarationDetailViewModel {
         SummaryListRow(
           key = Key(content = Text(messages("cf.cash-account.csv.vat"))),
           value = Value(content = HtmlContent(
-            Formatters.formatCurrencyAmount(declaration.taxGroups.find(_.taxTypeGroup == ImportVat)
+            Formatters.formatCurrencyAmount(declaration.taxGroups.find(_.taxGroupDescription == ImportVat)
               .map(_.amount)
               .getOrElse(BigDecimal(0)))
           )),
@@ -86,7 +86,7 @@ object DeclarationDetailViewModel {
         SummaryListRow(
           key = Key(content = Text(messages("cf.cash-account.csv.excise"))),
           value = Value(content = HtmlContent(
-            declaration.taxGroups.find(_.taxTypeGroup == ExciseDuty)
+            declaration.taxGroups.find(_.taxGroupDescription == ExciseDuty)
               .map(_.amount)
               .fold(emptyString)(amount => Formatters.formatCurrencyAmount(amount))
           )),

--- a/app/viewmodels/DeclarationDetailViewModel.scala
+++ b/app/viewmodels/DeclarationDetailViewModel.scala
@@ -34,28 +34,23 @@ object DeclarationDetailViewModel {
       rows = Seq(
         SummaryListRow(
           key = Key(content = Text(messages("cf.cash-account.csv.date"))),
-          value = Value(content = HtmlContent(Formatters.dateAsDayMonthAndYear(declaration.date))),
-          actions = None
+          value = Value(content = HtmlContent(Formatters.dateAsDayMonthAndYear(declaration.date)))
         ),
         SummaryListRow(
           key = Key(content = Text(messages("cf.cash-account.csv.movementReferenceNumber"))),
-          value = Value(content = HtmlContent(declaration.movementReferenceNumber)),
-          actions = None
+          value = Value(content = HtmlContent(declaration.movementReferenceNumber))
         ),
         SummaryListRow(
           key = Key(content = Text(messages("cf.cash-account.csv.uniqueConsignmentReference"))),
-          value = Value(content = HtmlContent(declaration.declarantReference.getOrElse(emptyString))),
-          actions = None
+          value = Value(content = HtmlContent(declaration.declarantReference.getOrElse(emptyString)))
         ),
         SummaryListRow(
           key = Key(content = Text(messages("cf.cash-account.csv.declarantEori"))),
-          value = Value(content = HtmlContent(declaration.declarantEori)),
-          actions = None
+          value = Value(content = HtmlContent(declaration.declarantEori))
         ),
         SummaryListRow(
           key = Key(content = Text(messages("cf.cash-account.csv.importerEori"))),
-          value = Value(content = HtmlContent(declaration.importerEori.getOrElse(emptyString))),
-          actions = None
+          value = Value(content = HtmlContent(declaration.importerEori.getOrElse(emptyString)))
         )
       )
     )
@@ -71,8 +66,7 @@ object DeclarationDetailViewModel {
             Formatters.formatCurrencyAmount(declaration.taxGroups.find(_.taxGroupDescription == CustomsDuty)
               .map(_.amount)
               .getOrElse(BigDecimal(0)))
-          )),
-          actions = None
+          ))
         ),
         SummaryListRow(
           key = Key(content = Text(messages("cf.cash-account.csv.vat"))),
@@ -80,8 +74,7 @@ object DeclarationDetailViewModel {
             Formatters.formatCurrencyAmount(declaration.taxGroups.find(_.taxGroupDescription == ImportVat)
               .map(_.amount)
               .getOrElse(BigDecimal(0)))
-          )),
-          actions = None
+          ))
         ),
         SummaryListRow(
           key = Key(content = Text(messages("cf.cash-account.csv.excise"))),
@@ -89,15 +82,13 @@ object DeclarationDetailViewModel {
             declaration.taxGroups.find(_.taxGroupDescription == ExciseDuty)
               .map(_.amount)
               .fold(emptyString)(amount => Formatters.formatCurrencyAmount(amount))
-          )),
-          actions = None
+          ))
         ),
         SummaryListRow(
           key = Key(content = Text(messages("cf.cash-account.detail.total.paid"))),
           value = Value(content = HtmlContent(
             Formatters.formatCurrencyAmount(declaration.amount)
-          )),
-          actions = None
+          ))
         )
       )
     )

--- a/app/viewmodels/DeclarationDetailViewModel.scala
+++ b/app/viewmodels/DeclarationDetailViewModel.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels
+
+import helpers.Formatters
+import models.{CashAccount, CustomsDuty, Declaration, ExciseDuty, ImportVat}
+import models.domain.EORI
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.Aliases.{HtmlContent, SummaryList, SummaryListRow, Text}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, Value}
+import utils.Utils.emptyString
+
+case class DeclarationDetailViewModel(eori: EORI, account: CashAccount)
+
+object DeclarationDetailViewModel {
+
+  def declarationSummaryList(declaration: Declaration)(implicit messages: Messages): SummaryList = {
+    SummaryList(
+      attributes = Map("id" -> "mrn"),
+      rows = Seq(
+        SummaryListRow(
+          key = Key(content = Text(messages("cf.cash-account.csv.date"))),
+          value = Value(content = HtmlContent(Formatters.dateAsDayMonthAndYear(declaration.date))),
+          actions = None
+        ),
+        SummaryListRow(
+          key = Key(content = Text(messages("cf.cash-account.csv.movementReferenceNumber"))),
+          value = Value(content = HtmlContent(declaration.movementReferenceNumber)),
+          actions = None
+        ),
+        SummaryListRow(
+          key = Key(content = Text(messages("cf.cash-account.csv.uniqueConsignmentReference"))),
+          value = Value(content = HtmlContent(declaration.declarantReference.getOrElse(emptyString))),
+          actions = None
+        ),
+        SummaryListRow(
+          key = Key(content = Text(messages("cf.cash-account.csv.declarantEori"))),
+          value = Value(content = HtmlContent(declaration.declarantEori)),
+          actions = None
+        ),
+        SummaryListRow(
+          key = Key(content = Text(messages("cf.cash-account.csv.importerEori"))),
+          value = Value(content = HtmlContent(declaration.importerEori.getOrElse(emptyString))),
+          actions = None
+        )
+      )
+    )
+  }
+
+  def taxSummaryList(declaration: Declaration)(implicit messages: Messages): SummaryList = {
+    SummaryList(
+      attributes = Map("id" -> "tax-details"),
+      rows = Seq(
+        SummaryListRow(
+          key = Key(content = Text(messages("cf.cash-account.csv.duty"))),
+          value = Value(content = HtmlContent(
+            Formatters.formatCurrencyAmount(declaration.taxGroups.find(_.taxTypeGroup == CustomsDuty)
+              .map(_.amount)
+              .getOrElse(BigDecimal(0)))
+          )),
+          actions = None
+        ),
+        SummaryListRow(
+          key = Key(content = Text(messages("cf.cash-account.csv.vat"))),
+          value = Value(content = HtmlContent(
+            Formatters.formatCurrencyAmount(declaration.taxGroups.find(_.taxTypeGroup == ImportVat)
+              .map(_.amount)
+              .getOrElse(BigDecimal(0)))
+          )),
+          actions = None
+        ),
+        SummaryListRow(
+          key = Key(content = Text(messages("cf.cash-account.csv.excise"))),
+          value = Value(content = HtmlContent(
+            Formatters.formatCurrencyAmount(declaration.taxGroups.find(_.taxTypeGroup == ExciseDuty)
+              .map(_.amount)
+              .getOrElse(BigDecimal(0)))
+          )),
+          actions = None
+        ),
+        SummaryListRow(
+          key = Key(content = Text(messages("cf.cash-account.detail.total.paid"))),
+          value = Value(content = HtmlContent(
+            Formatters.formatCurrencyAmount(declaration.amount)
+          )),
+          actions = None
+        )
+      )
+    )
+  }
+}

--- a/app/views/cash_account_declaration_details.scala.html
+++ b/app/views/cash_account_declaration_details.scala.html
@@ -1,0 +1,43 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import helpers.Formatters
+@import viewmodels.DeclarationDetailViewModel
+
+@this(main_template: Layout, govukSummaryList: GovukSummaryList, h1: components.h1)
+
+@(viewModel: DeclarationDetailViewModel,
+  declarations: Declaration,
+  pageNumber: Option[Int]
+)(implicit request: Request[_], messages: Messages)
+
+@main_template(
+  pageTitle = Some(messages("cf.cash-account.detail.title")),
+  backLink = Some(routes.CashAccountController.showAccountDetails(page = pageNumber).url),
+  fullWidth = false
+) {
+
+  <h2 class="govuk-caption-xl" id="account-number">
+    @messages("cf.cash-account.detail.account", viewModel.account.number)
+  </h2>
+
+  @h1(msg="cf.cash-account.detail.declaration.title")
+
+  @govukSummaryList(DeclarationDetailViewModel.declarationSummaryList(declarations))
+
+  @govukSummaryList(DeclarationDetailViewModel.taxSummaryList(declarations))
+
+}

--- a/app/views/cash_account_declaration_details.scala.html
+++ b/app/views/cash_account_declaration_details.scala.html
@@ -17,10 +17,10 @@
 @import helpers.Formatters
 @import viewmodels.DeclarationDetailViewModel
 
-@this(main_template: Layout, govukSummaryList: GovukSummaryList, h1: components.h1)
+@this(main_template: Layout, govukSummaryList: GovukSummaryList, h1: components.h1, h2: components.h2Inner)
 
 @(viewModel: DeclarationDetailViewModel,
-  declarations: Declaration,
+  declarationDetails: Declaration,
   pageNumber: Option[Int]
 )(implicit request: Request[_], messages: Messages)
 
@@ -30,14 +30,16 @@
   fullWidth = false
 ) {
 
-  <h2 class="govuk-caption-xl" id="account-number">
-    @messages("cf.cash-account.detail.account", viewModel.account.number)
-  </h2>
+  @h2(msg = "cf.cash-account.detail.account",
+      innerMsg = viewModel.account.number,
+      id = Some("account-number"),
+      classes = "govuk-caption-xl"
+  )
 
   @h1(msg="cf.cash-account.detail.declaration.title")
 
-  @govukSummaryList(DeclarationDetailViewModel.declarationSummaryList(declarations))
+  @govukSummaryList(DeclarationDetailViewModel.declarationSummaryList(declarationDetails))
 
-  @govukSummaryList(DeclarationDetailViewModel.taxSummaryList(declarations))
+  @govukSummaryList(DeclarationDetailViewModel.taxSummaryList(declarationDetails))
 
 }

--- a/app/views/components/h2Inner.scala.html
+++ b/app/views/components/h2Inner.scala.html
@@ -19,9 +19,10 @@
 @this()
 
 @(
-  msg: String,
-  id: Option[String],
-  classes: String = "govuk-heading-m"
+ msg: String,
+ innerMsg: String,
+ id: Option[String] = None,
+ classes: String = "govuk-heading-m"
 )(implicit messages: Messages)
 
-<h2 @{id.fold(emptyString)(id => s"id=$id")} class="@classes">@messages(msg)</h2>
+<h2 class="@classes" @{id.fold(emptyString)(id => s"id=$id")}>@messages(msg, messages(innerMsg))</h2>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -23,3 +23,5 @@ GET         /logout                                 controllers.LogoutController
 GET         /download-requested-csv                 controllers.DownloadCsvController.downloadRequestedCsv(disposition: Option[String], range: models.RequestedDateRange)
 GET         /download-csv                           controllers.DownloadCsvController.downloadCsv(disposition: Option[String])
 GET         /csv-download-error                     controllers.DownloadCsvController.showUnableToDownloadCSV()
+
+GET         /transaction/:ref                       controllers.DeclarationDetailController.displayDetails(ref: String, page: Option[Int])

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -84,7 +84,8 @@ cf.cash-account.detail.unable-download-csv=Mae’n ddrwg gennym – roedd proble
 cf.cash-account.detail.try-again-later=Rhowch gynnig arall arni yn nes ymlaen.
 cf.cash-account-detail.back-to-cash-account=Yn ôl i ‘Cyfrif arian parod’
 cf.cash-account-detail.exceeded-threshold = <p>Mae gormod o drafodion o’r 6 mis diwethaf i’w harddangos yn olynol.</p><p>Bwrw golwg dros drafodion blaenorol o gyfnod byrrach gan ddefnyddio’r cysylltiad chwilio isod.</p>
-
+cf.cash-account.detail.declaration.title=Trafodiad datganiad
+cf.cash-account.detail.total.paid=Cyfanswm a dalwyd
 
 # Timeout Messages
 # ----------------------------------------------------------

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -85,7 +85,8 @@ cf.cash-account.detail.unable-download-csv=Sorry, there was a problem downloadin
 cf.cash-account.detail.try-again-later=Try again later.
 cf.cash-account-detail.back-to-cash-account=Back to Cash account
 cf.cash-account-detail.exceeded-threshold = <p>There are too many transactions from the last 6 months to display consecutively.</p><p>View previous transactions from a narrower date period using the search link below.</p>
-
+cf.cash-account.detail.declaration.title=Declaration transaction
+cf.cash-account.detail.total.paid=Total paid
 
 # Timeout Messages
 # ----------------------------------------------------------

--- a/test/controllers/CashAccountControllerSpec.scala
+++ b/test/controllers/CashAccountControllerSpec.scala
@@ -454,6 +454,7 @@ class CashAccountControllerSpec extends SpecBase {
     val cashAccountNumber = "1234567"
     val eori = "exampleEori"
     val someCan = "1234567"
+    val sMRN = "ic62zbad-75fa-445f-962b-cc92311686b8e"
 
     val mockCustomsFinancialsApiConnector: CustomsFinancialsApiConnector = mock[CustomsFinancialsApiConnector]
     val mockAuditingService: AuditingService = mock[AuditingService]
@@ -464,7 +465,7 @@ class CashAccountControllerSpec extends SpecBase {
 
     val listOfPendingTransactions: Seq[Declaration] =
       Seq(Declaration("pendingDeclarationID", Some("pendingImporterEORI"), "pendingDeclarantEORINumber",
-        Some("pendingDeclarantReference"), LocalDate.parse("2020-07-21"), -100.00, Nil))
+        Some("pendingDeclarantReference"), LocalDate.parse("2020-07-21"), -100.00, Nil, Some(sMRN)))
 
     val fromDate: LocalDate = LocalDate.parse("2019-10-08")
     val toDate: LocalDate = LocalDate.parse("2020-04-08")
@@ -472,17 +473,17 @@ class CashAccountControllerSpec extends SpecBase {
     val cashDailyStatements: Seq[CashDailyStatement] = Seq(
       CashDailyStatement(LocalDate.parse("2020-07-18"), 0.0, 1000.00,
         Seq(Declaration("mrn1", Some("Importer EORI"), "Declarant EORI", Some("Declarant Reference"),
-          LocalDate.parse("2020-07-18"), -84.00, Nil),
+          LocalDate.parse("2020-07-18"), -84.00, Nil, Some(sMRN)),
           Declaration("mrn2", Some("Importer EORI"), "Declarant EORI", Some("Declarant Reference"),
-            LocalDate.parse("2020-07-18"), -65.00, Nil)),
+            LocalDate.parse("2020-07-18"), -65.00, Nil, Some(sMRN))),
 
         Seq(Transaction(45.67, Payment, None), Transaction(-76.34, Withdrawal, Some("77665544")))),
 
       CashDailyStatement(LocalDate.parse("2020-07-20"), 0.0, 1200.00,
         Seq(Declaration("mrn3", Some("Importer EORI"), "Declarant EORI", Some("Declarant Reference"),
-          LocalDate.parse("2020-07-20"), -90.00, Nil),
+          LocalDate.parse("2020-07-20"), -90.00, Nil, Some(sMRN)),
           Declaration("mrn4", Some("Importer EORI"), "Declarant EORI", Some("Declarant Reference"),
-            LocalDate.parse("2020-07-20"), -30.00, Nil)),
+            LocalDate.parse("2020-07-20"), -30.00, Nil, Some(sMRN))),
         Seq(Transaction(67.89, Payment, None))))
 
     val nonFatalResponse: UpstreamErrorResponse = UpstreamErrorResponse(
@@ -518,7 +519,9 @@ class CashAccountControllerSpec extends SpecBase {
       randomString(randomStringLength),
       Some(randomString(randomStringLength)),
       randomLocalDate,
-      randomBigDecimal, Nil)
+      randomBigDecimal,
+      Nil,
+      Some("ic62zbad-75fa-445f-962b-cc92311686b8e"))
   }
 
   def randomCashDailyStatement: CashDailyStatement = {

--- a/test/controllers/DeclarationDetailControllerSpec.scala
+++ b/test/controllers/DeclarationDetailControllerSpec.scala
@@ -34,7 +34,6 @@ class DeclarationDetailControllerSpec extends SpecBase {
   "Cash Account Declaration Transaction Details" must {
 
     "return an OK view when a transaction is found" in new Setup {
-
       when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
         .thenReturn(Future.successful(Some(cashAccount)))
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))

--- a/test/controllers/DeclarationDetailControllerSpec.scala
+++ b/test/controllers/DeclarationDetailControllerSpec.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import connectors.*
+import models.*
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.when
+import play.api.Application
+import play.api.inject.bind
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import utils.SpecBase
+
+import java.time.LocalDate
+import scala.concurrent.Future
+
+class DeclarationDetailControllerSpec extends SpecBase {
+
+  "Cash Account Declaration Transaction Details" must {
+
+    "return an OK view when a transaction is found" in new Setup {
+
+      when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
+        .thenReturn(Future.successful(Some(cashAccount)))
+      when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
+        .thenReturn(Future.successful(Right(cashTransactionResponse)))
+
+      val app: Application = application
+        .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
+        .build()
+
+      running(app) {
+        val request = FakeRequest(GET, routes.DeclarationDetailController.displayDetails(sMRN, Some(1)).url)
+          .withSession("eori" -> eori)
+
+        val result = route(app, request).value
+
+        status(result) mustEqual OK
+      }
+    }
+
+    "return an OK view with no transactions when an error occurs during retrieval" in new Setup {
+      when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
+        .thenReturn(Future.successful(Some(cashAccount)))
+      when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
+        .thenReturn(Future.successful(Left(new Exception("API error"))))
+
+      val app: Application = application
+        .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
+        .build()
+
+      running(app) {
+        val request = FakeRequest(GET, routes.DeclarationDetailController.displayDetails(sMRN, Some(1)).url)
+          .withSession("eori" -> eori)
+
+        val result = route(app, request).value
+
+        status(result) mustBe OK
+      }
+    }
+
+    "return a NOT_FOUND when the transaction details not found in the retrieved data" in new Setup {
+      when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
+        .thenReturn(Future.successful(Some(cashAccount)))
+      when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
+        .thenReturn(Future.successful(Right(CashTransactions(Seq.empty, Seq.empty))))
+
+      val app: Application = application
+        .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
+        .build()
+
+      running(app) {
+        val request =
+          FakeRequest(GET, routes.DeclarationDetailController.displayDetails("sMRN not found", Some(1)).url)
+            .withSession("eori" -> eori)
+
+        val result = route(app, request).value
+        status(result) mustBe NOT_FOUND
+      }
+    }
+
+    "return a NOT_FOUND when the transaction details not retrieved" in new Setup {
+      when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
+        .thenReturn(Future.successful(None))
+
+      val app: Application = application
+        .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
+        .build()
+
+      running(app) {
+        val request = FakeRequest(GET, routes.DeclarationDetailController.displayDetails(sMRN, Some(1)).url)
+          .withSession("eori" -> eori)
+        val result = route(app, request).value
+
+        status(result) mustBe NOT_FOUND
+      }
+    }
+  }
+
+  trait Setup {
+
+    val cashAccountNumber = "1234567"
+    val eori = "exampleEori"
+    val sMRN = "ic62zbad-75fa-445f-962b-cc92311686b8e"
+
+    val fromDate: LocalDate = LocalDate.parse("2019-10-08")
+    val toDate: LocalDate = LocalDate.parse("2020-04-08")
+
+    val mockCustomsFinancialsApiConnector: CustomsFinancialsApiConnector = mock[CustomsFinancialsApiConnector]
+
+    val cashAccount: CashAccount = CashAccount(
+      cashAccountNumber,
+      eori,
+      AccountStatusOpen,
+      CDSCashBalance(Some(BigDecimal(123456.78)))
+    )
+
+    val listOfPendingTransactions: Seq[Declaration] = Seq(
+      Declaration("pendingDeclarationID", Some("pendingImporterEORI"), "pendingDeclarantEORINumber",
+        Some("pendingDeclarantReference"), LocalDate.parse("2020-07-21"), -100.00, Nil, Some(sMRN))
+    )
+
+    val cashDailyStatements: Seq[CashDailyStatement] = Seq(
+      CashDailyStatement(LocalDate.parse("2020-07-18"), 0.0, 1000.00,
+        Seq(Declaration("mrn1", Some("Importer EORI"), "Declarant EORI", Some("Declarant Reference"),
+          LocalDate.parse("2020-07-18"), -84.00, Nil, Some(sMRN)),
+          Declaration("mrn2", Some("Importer EORI"), "Declarant EORI", Some("Declarant Reference"),
+            LocalDate.parse("2020-07-18"), -65.00, Nil, Some(sMRN))),
+
+        Seq(Transaction(45.67, Payment, None), Transaction(-76.34, Withdrawal, Some("77665544")))),
+
+      CashDailyStatement(LocalDate.parse("2020-07-20"), 0.0, 1200.00,
+        Seq(Declaration("mrn3", Some("Importer EORI"), "Declarant EORI", Some("Declarant Reference"),
+          LocalDate.parse("2020-07-20"), -90.00, Nil, Some(sMRN)),
+          Declaration("mrn4", Some("Importer EORI"), "Declarant EORI", Some("Declarant Reference"),
+            LocalDate.parse("2020-07-20"), -30.00, Nil, Some(sMRN))),
+        Seq(Transaction(67.89, Payment, None))))
+
+    val cashTransactionResponse: CashTransactions = CashTransactions(
+      listOfPendingTransactions, cashDailyStatements)
+  }
+}

--- a/test/controllers/DownloadCsvControllerSpec.scala
+++ b/test/controllers/DownloadCsvControllerSpec.scala
@@ -170,7 +170,7 @@ class DownloadCsvControllerSpec extends SpecBase {
         .overrides(
           bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector)
         ).configure("features.fixed-systemdate-for-tests" -> "true"
-      ).build()
+        ).build()
 
       running(app) {
         val request = FakeRequest(GET, routes.DownloadCsvController.downloadCsv(None).url)
@@ -196,7 +196,7 @@ class DownloadCsvControllerSpec extends SpecBase {
           bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
           bind[AuditingService].toInstance(mockAuditingService)
         ).configure("features.fixed-systemdate-for-tests" -> "true"
-      ).build()
+        ).build()
 
       running(app) {
         val request = FakeRequest(GET, routes.DownloadCsvController.downloadCsv(None).url)
@@ -220,7 +220,7 @@ class DownloadCsvControllerSpec extends SpecBase {
         .overrides(
           bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector)
         ).configure("features.fixed-systemdate-for-tests" -> "true"
-      ).build()
+        ).build()
 
       running(app) {
         val request = FakeRequest(GET, routes.DownloadCsvController.downloadCsv(None).url)
@@ -397,6 +397,7 @@ class DownloadCsvControllerSpec extends SpecBase {
     val cashAccountNumber = "1234567"
     val eori = "exampleEori"
     val someCan = "1234567"
+    val sMRN = "ic62zbad-75fa-445f-962b-cc92311686b8e"
 
     val mockAuditingService: AuditingService = mock[AuditingService]
     val mockCustomsFinancialsApiConnector: CustomsFinancialsApiConnector = mock[CustomsFinancialsApiConnector]
@@ -406,7 +407,7 @@ class DownloadCsvControllerSpec extends SpecBase {
     val listOfPendingTransactions: Seq[Declaration] =
       Seq(Declaration("pendingDeclarationID", Some("pendingImporterEORI"),
         "pendingDeclarantEORINumber", Some("pendingDeclarantReference"),
-        LocalDate.parse("2020-07-21"), -100.00, Nil))
+        LocalDate.parse("2020-07-21"), -100.00, Nil, Some(sMRN)))
 
     val day = 10
     val month = 10
@@ -418,16 +419,16 @@ class DownloadCsvControllerSpec extends SpecBase {
     val cashDailyStatements: Seq[CashDailyStatement] = Seq(
       CashDailyStatement(LocalDate.parse("2020-07-18"), 0.0, 1000.00,
         Seq(Declaration("mrn1", Some("Importer EORI"), "Declarant EORI",
-          Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.00, Nil),
+          Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.00, Nil, Some(sMRN)),
           Declaration("mrn2", Some("Importer EORI"), "Declarant EORI",
-            Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -65.00, Nil)),
+            Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -65.00, Nil, Some(sMRN))),
         Seq(Transaction(45.67, Payment, None), Transaction(-76.34, Withdrawal, Some("77665544")))),
 
       CashDailyStatement(LocalDate.parse("2020-07-20"), 0.0, 1200.00,
         Seq(Declaration("mrn3", Some("Importer EORI"), "Declarant EORI",
-          Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -90.00, Nil),
+          Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -90.00, Nil, Some(sMRN)),
           Declaration("mrn4", Some("Importer EORI"), "Declarant EORI",
-            Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -30.00, Nil)),
+            Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -30.00, Nil, Some(sMRN))),
         Seq(Transaction(67.89, Payment, None)))
     )
 
@@ -472,7 +473,9 @@ class DownloadCsvControllerSpec extends SpecBase {
       randomString(randomStringLength),
       Some(randomString(randomStringLength)),
       randomLocalDate,
-      randomBigDecimal, Nil)
+      randomBigDecimal,
+      Nil,
+      Some("ic62zbad-75fa-445f-962b-cc92311686b8e"))
   }
 
   def randomCashDailyStatement: CashDailyStatement = {

--- a/test/controllers/RequestedTransactionsControllerSpec.scala
+++ b/test/controllers/RequestedTransactionsControllerSpec.scala
@@ -178,6 +178,8 @@ class RequestedTransactionsControllerSpec extends SpecBase {
     val cashAccountNumber = "1234567"
     val eori = "exampleEori"
     val someCan = "1234567"
+    val sMRN = "ic62zbad-75fa-445f-962b-cc92311686b8e"
+
     val mockCustomsFinancialsApiConnector: CustomsFinancialsApiConnector = mock[CustomsFinancialsApiConnector]
     val mockRequestedTransactionsCache: RequestedTransactionsCache = mock[RequestedTransactionsCache]
 
@@ -187,7 +189,7 @@ class RequestedTransactionsControllerSpec extends SpecBase {
     val listOfPendingTransactions: Seq[Declaration] =
       Seq(Declaration("pendingDeclarationID", Some("pendingImporterEORI"),
         "pendingDeclarantEORINumber", Some("pendingDeclarantReference"),
-        LocalDate.parse("2020-07-21"), -100.00, Nil))
+        LocalDate.parse("2020-07-21"), -100.00, Nil, Some(sMRN)))
 
     val fromDate: LocalDate = LocalDate.parse("2023-03-30")
     val toDate: LocalDate = LocalDate.parse("2023-03-30")
@@ -195,16 +197,16 @@ class RequestedTransactionsControllerSpec extends SpecBase {
     val cashDailyStatements: Seq[CashDailyStatement] = Seq(
       CashDailyStatement(LocalDate.parse("2020-07-18"), 0.0, 1000.00,
         Seq(Declaration("mrn1", Some("Importer EORI"), "Declarant EORI",
-          Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.00, Nil),
+          Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.00, Nil, Some(sMRN)),
           Declaration("mrn2", Some("Importer EORI"), "Declarant EORI",
-            Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -65.00, Nil)),
+            Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -65.00, Nil, Some(sMRN))),
         Seq(Transaction(45.67, Payment, None), Transaction(-76.34, Withdrawal, Some("77665544")))),
 
       CashDailyStatement(LocalDate.parse("2020-07-20"), 0.0, 1200.00,
         Seq(Declaration("mrn3", Some("Importer EORI"), "Declarant EORI",
-          Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -90.00, Nil),
+          Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -90.00, Nil, Some(sMRN)),
           Declaration("mrn4", Some("Importer EORI"), "Declarant EORI",
-            Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -30.00, Nil)),
+            Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -30.00, Nil, Some(sMRN))),
         Seq(Transaction(67.89, Payment, None)))
     )
 

--- a/test/controllers/SelectedTransactionsControllerSpec.scala
+++ b/test/controllers/SelectedTransactionsControllerSpec.scala
@@ -171,6 +171,7 @@ class SelectedTransactionsControllerSpec extends SpecBase {
   }
 
   trait Setup {
+    val sMRN: Option[String] = Some("ic62zbad-75fa-445f-962b-cc92311686b8e")
     val cashAccountNumber = "1234567"
     val eori = "exampleEori"
     val someCan = "1234567"
@@ -183,7 +184,7 @@ class SelectedTransactionsControllerSpec extends SpecBase {
     val listOfPendingTransactions: Seq[Declaration] =
       Seq(Declaration("pendingDeclarationID", Some("pendingImporterEORI"),
         "pendingDeclarantEORINumber", Some("pendingDeclarantReference"),
-        LocalDate.parse("2020-07-21"), -100.00, Nil))
+        LocalDate.parse("2020-07-21"), -100.00, Nil, sMRN))
 
     val fromDate: LocalDate = LocalDate.parse("2023-03-30")
     val toDate: LocalDate = LocalDate.parse("2023-03-30")
@@ -191,16 +192,16 @@ class SelectedTransactionsControllerSpec extends SpecBase {
     val cashDailyStatements: Seq[CashDailyStatement] = Seq(
       CashDailyStatement(LocalDate.parse("2020-07-18"), 0.0, 1000.00,
         Seq(Declaration("mrn1", Some("Importer EORI"), "Declarant EORI",
-          Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.00, Nil),
+          Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.00, Nil, sMRN),
           Declaration("mrn2", Some("Importer EORI"), "Declarant EORI",
-            Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -65.00, Nil)),
+            Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -65.00, Nil, sMRN)),
         Seq(Transaction(45.67, Payment, None), Transaction(-76.34, Withdrawal, Some("77665544")))),
 
       CashDailyStatement(LocalDate.parse("2020-07-20"), 0.0, 1200.00,
         Seq(Declaration("mrn3", Some("Importer EORI"), "Declarant EORI",
-          Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -90.00, Nil),
+          Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -90.00, Nil, sMRN),
           Declaration("mrn4", Some("Importer EORI"), "Declarant EORI",
-            Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -30.00, Nil)),
+            Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -30.00, Nil, sMRN)),
         Seq(Transaction(67.89, Payment, None)))
     )
 

--- a/test/crypto/CashTransactionsEncrypterSpec.scala
+++ b/test/crypto/CashTransactionsEncrypterSpec.scala
@@ -26,26 +26,27 @@ class CashTransactionsEncrypterSpec extends SpecBase {
   private val cipher = new AesGCMCrypto
   private val encrypter = new CashTransactionsEncrypter(cipher)
   private val secretKey = "VqmXp7yigDFxbCUdDdNZVIvbW6RgPNJsliv6swQNCL8="
+  private val sMRN = "ic62zbad-75fa-445f-962b-cc92311686b8e"
 
   trait Setup {
     val listOfPendingTransactions: Seq[Declaration] =
       Seq(Declaration("pendingDeclarationID", Some("pendingImporterEORI"),
         "pendingDeclarantEORINumber", Some("pendingDeclarantReference"),
-        LocalDate.parse("2020-07-21"), -100.00, Nil))
+        LocalDate.parse("2020-07-21"), -100.00, Nil, Some(sMRN)))
 
     val cashDailyStatements: Seq[CashDailyStatement] = Seq(
       CashDailyStatement(LocalDate.parse("2020-07-18"), 0.0, 1000.00,
         Seq(Declaration("mrn1", Some("importer EORI"), "Declarant EORI",
-          Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.00, Nil),
+          Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.00, Nil, Some(sMRN)),
           Declaration("mrn2", Some("Importer EORI"), "Declarant EORI",
-            Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -65.00, Nil)),
+            Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -65.00, Nil, Some(sMRN))),
         Seq(Transaction(45.67, Payment, None), Transaction(-76.34, Withdrawal, Some("77665544")))),
 
       CashDailyStatement(LocalDate.parse("2020-07-20"), 0.0, 1200.00,
         Seq(Declaration("mrn3", Some("Importer EORI"), "Declarant EORI",
-          Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -90.00, Nil),
+          Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -90.00, Nil, Some(sMRN)),
           Declaration("mrn4", Some("Importer EORI"), "Declarant EORI",
-            Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -30.00, Nil)),
+            Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -30.00, Nil, Some(sMRN))),
         Seq(Transaction(67.89, Payment, None))))
 
     val cashTransactions: CashTransactions = CashTransactions(listOfPendingTransactions, cashDailyStatements)

--- a/test/models/DeclarationSpec.scala
+++ b/test/models/DeclarationSpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import utils.SpecBase
+
+import play.api.libs.json._
+import java.time.LocalDate
+import crypto.EncryptedValue
+
+class DeclarationSpec extends SpecBase {
+
+  "Declaration format" should {
+
+    "serialize and deserialize a Declaration with all fields populated" in new Setup {
+
+      val json: JsValue = Declaration.format.writes(declarations)
+      val result: Declaration = Declaration.format.reads(json).get
+      result mustBe declarations
+    }
+
+    "handle missing optional fields in Declaration" in new Setup {
+      val declarationWithFieldsMissing: Declaration = declarations.copy(
+        importerEori = None,
+        declarantReference = None,
+        secureMovementReferenceNumber = None
+      )
+
+      val json: JsValue = Declaration.format.writes(declarationWithFieldsMissing)
+      val result: Declaration = Declaration.format.reads(json).get
+      result mustBe declarationWithFieldsMissing
+    }
+  }
+
+  "EncryptedDeclaration format" should {
+
+    "serialize and deserialize an EncryptedDeclaration with all fields populated" in new Setup {
+
+      val json: JsValue = EncryptedDeclaration.format.writes(encryptedDeclaration)
+      val result: EncryptedDeclaration = EncryptedDeclaration.format.reads(json).get
+      result mustBe encryptedDeclaration
+    }
+  }
+
+  trait Setup {
+
+    val year = 2024
+    val month = 5
+    val day = 5
+
+    val date: LocalDate = LocalDate.of(year, month, day)
+    val thousand: BigDecimal = BigDecimal(1000.00)
+    val twoThousand: BigDecimal = BigDecimal(2000.00)
+
+    val movementReferenceNumber = "MRN1234567890"
+    val nonce = "someNone"
+    val importerEori = "GB123456789000"
+    val declarantEori = "GB987654321000"
+    val declarantReference = "UCR12345"
+    val secureMovementReferenceNumber = "5a71a767-5c1c-4df8-8eef-2b83769b8fda"
+
+    val declarations: Declaration = Declaration(
+      movementReferenceNumber = movementReferenceNumber,
+      importerEori = Some(importerEori),
+      declarantEori = declarantEori,
+      declarantReference = Some(declarantReference),
+      date = date,
+      amount = twoThousand,
+      taxGroups = Seq(
+        TaxGroup(CustomsDuty, twoThousand),
+        TaxGroup(ImportVat, thousand),
+        TaxGroup(ExciseDuty, twoThousand)
+      ),
+      secureMovementReferenceNumber = Some(secureMovementReferenceNumber)
+    )
+
+    val encryptedDeclaration: EncryptedDeclaration = EncryptedDeclaration(
+      movementReferenceNumber = EncryptedValue(movementReferenceNumber, nonce),
+      importerEori = EncryptedValue(importerEori, nonce),
+      declarantEori = EncryptedValue(declarantEori, nonce),
+      declarantReference = Some(EncryptedValue(declarantReference, nonce)),
+      date = date,
+      amount = thousand,
+      taxGroups = Seq(
+        TaxGroup(CustomsDuty, twoThousand),
+        TaxGroup(ImportVat, thousand),
+        TaxGroup(ExciseDuty, twoThousand)
+      ),
+      secureMovementReferenceNumber = secureMovementReferenceNumber
+    )
+  }
+}

--- a/test/models/DeclarationSpec.scala
+++ b/test/models/DeclarationSpec.scala
@@ -73,6 +73,8 @@ class DeclarationSpec extends SpecBase {
     val declarantReference = "UCR12345"
     val secureMovementReferenceNumber = "5a71a767-5c1c-4df8-8eef-2b83769b8fda"
 
+    val taxTypes: Seq[TaxType] = Seq(TaxType(reasonForSecurity = "Reason", taxTypeID = "50", amount = thousand))
+
     val declarations: Declaration = Declaration(
       movementReferenceNumber = movementReferenceNumber,
       importerEori = Some(importerEori),
@@ -81,9 +83,9 @@ class DeclarationSpec extends SpecBase {
       date = date,
       amount = twoThousand,
       taxGroups = Seq(
-        TaxGroup(CustomsDuty, twoThousand),
-        TaxGroup(ImportVat, thousand),
-        TaxGroup(ExciseDuty, twoThousand)
+        TaxGroup(CustomsDuty, twoThousand, taxTypes),
+        TaxGroup(ImportVat, thousand, taxTypes),
+        TaxGroup(ExciseDuty, twoThousand, taxTypes)
       ),
       secureMovementReferenceNumber = Some(secureMovementReferenceNumber)
     )
@@ -96,9 +98,9 @@ class DeclarationSpec extends SpecBase {
       date = date,
       amount = thousand,
       taxGroups = Seq(
-        TaxGroup(CustomsDuty, twoThousand),
-        TaxGroup(ImportVat, thousand),
-        TaxGroup(ExciseDuty, twoThousand)
+        TaxGroup(CustomsDuty, twoThousand, taxTypes),
+        TaxGroup(ImportVat, thousand, taxTypes),
+        TaxGroup(ExciseDuty, twoThousand, taxTypes)
       ),
       secureMovementReferenceNumber = secureMovementReferenceNumber
     )

--- a/test/models/DeclarationSpec.scala
+++ b/test/models/DeclarationSpec.scala
@@ -27,7 +27,6 @@ class DeclarationSpec extends SpecBase {
   "Declaration format" should {
 
     "serialize and deserialize a Declaration with all fields populated" in new Setup {
-
       val json: JsValue = Declaration.format.writes(declarations)
       val result: Declaration = Declaration.format.reads(json).get
       result mustBe declarations
@@ -49,7 +48,6 @@ class DeclarationSpec extends SpecBase {
   "EncryptedDeclaration format" should {
 
     "serialize and deserialize an EncryptedDeclaration with all fields populated" in new Setup {
-
       val json: JsValue = EncryptedDeclaration.format.writes(encryptedDeclaration)
       val result: EncryptedDeclaration = EncryptedDeclaration.format.reads(json).get
       result mustBe encryptedDeclaration

--- a/test/models/TaxGroupSpec.scala
+++ b/test/models/TaxGroupSpec.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{JsValue, Json, JsResultException}
+import utils.SpecBase
+
+class TaxGroupSpec extends SpecBase {
+
+  "TaxType" must {
+
+    "serialize and deserialize TaxType correctly" in new Setup {
+
+      val expectedTaxType: TaxType = TaxType("Reason", "VAT", hundred)
+      val serialized: JsValue = Json.toJson(expectedTaxType)
+      val deserialized: TaxType = serialized.as[TaxType]
+
+      deserialized mustBe expectedTaxType
+    }
+
+    "handle invalid JSON" in new Setup {
+
+      val invalidJson: JsValue = Json.obj("reason" -> "Reason", "type" -> "VAT")
+
+      intercept[JsResultException] {
+        invalidJson.as[TaxType]
+      }
+    }
+  }
+
+  "TaxGroup" must {
+
+    "serialize and deserialize TaxGroup correctly" in new Setup {
+
+      val expectedTaxGroup: TaxGroup = TaxGroup(
+        taxGroupDescription = CustomsDuty,
+        amount = fiveHundred,
+        taxTypes = Seq(taxType)
+      )
+
+      val serialized: JsValue = Json.toJson(expectedTaxGroup)
+      val deserialized: TaxGroup = serialized.as[TaxGroup]
+
+      deserialized mustBe expectedTaxGroup
+    }
+
+    "handle empty taxTypes sequence in TaxGroup" in new Setup {
+
+      val taxGroupWithEmptyTaxTypes: TaxGroup = TaxGroup(
+        taxGroupDescription = CustomsDuty,
+        amount = fiveHundred,
+        taxTypes = Seq.empty
+      )
+
+      val serialized: JsValue = Json.toJson(taxGroupWithEmptyTaxTypes)
+      val deserialized: TaxGroup = serialized.as[TaxGroup]
+
+      deserialized mustBe taxGroupWithEmptyTaxTypes
+    }
+
+    "handle invalid JSON" in new Setup {
+
+      val invalidJson: JsValue = Json.obj("taxGroupDescription" -> "CustomsDuty", "amount" -> hundred)
+
+      intercept[RuntimeException] {
+        invalidJson.as[TaxGroup]
+      }
+    }
+  }
+
+  trait Setup {
+
+    val hundred: BigDecimal = BigDecimal(100.50)
+    val twoHundred: BigDecimal = BigDecimal(200.50)
+    val fiveHundred: BigDecimal = BigDecimal(500.00)
+
+    val taxType: TaxType = TaxType("Reason", "VAT", hundred)
+
+    val taxGroup: TaxGroup = TaxGroup(
+      taxGroupDescription = CustomsDuty,
+      amount = fiveHundred,
+      taxTypes = Seq(taxType)
+    )
+  }
+}

--- a/test/viewmodels/CashTransactionCsvRowSpec.scala
+++ b/test/viewmodels/CashTransactionCsvRowSpec.scala
@@ -46,7 +46,7 @@ class CashTransactionCsvRowSpec extends SpecBase {
       TaxGroup(ExciseDuty, -3.45))
 
     val declarations: Seq[Declaration] =
-      Seq(Declaration("someMRN", Some("someImporterEORI"), "someEORI", None, dateWithDay4, -1234.56, taxGroups))
+      Seq(Declaration("someMRN", Some("someImporterEORI"), "someEORI", None, dateWithDay4, -1234.56, taxGroups, Some(sMRN)))
 
     override val dailyStatement: CashDailyStatement =
       CashDailyStatement(dateWithDay4, amountZero, amountZero, declarations, Nil)
@@ -72,9 +72,9 @@ class CashTransactionCsvRowSpec extends SpecBase {
   "order declaration rows by ascending MRN" in new Setup {
 
     val declarations: Seq[Declaration] = Seq(
-      Declaration("someMRN2", Some("someImporterEORI"), "someEORI", None, dateWithDay3, 1234.56, Nil),
-      Declaration("someMRN3", Some("someImporterEORI"), "someEORI", None, dateWithDay3, 1234.56, Nil),
-      Declaration("someMRN1", Some("someImporterEORI"), "someEORI", None, dateWithDay3, 1234.56, Nil))
+      Declaration("someMRN2", Some("someImporterEORI"), "someEORI", None, dateWithDay3, 1234.56, Nil, Some(sMRN)),
+      Declaration("someMRN3", Some("someImporterEORI"), "someEORI", None, dateWithDay3, 1234.56, Nil, Some(sMRN)),
+      Declaration("someMRN1", Some("someImporterEORI"), "someEORI", None, dateWithDay3, 1234.56, Nil, Some(sMRN)))
 
     override val dailyStatement: CashDailyStatement =
       CashDailyStatement(dateWithDay4, amountZero, amountZero, declarations, Nil)
@@ -90,7 +90,7 @@ class CashTransactionCsvRowSpec extends SpecBase {
   "default vat/duty/excise to zero if not found in the declaration" in new Setup {
     val taxGroups = Nil
     val declarations: Seq[Declaration] = Seq(
-      Declaration("someMRN", Some("someImporterEORI"), "someEORI", None, dateWithDay3, 1234.56, taxGroups))
+      Declaration("someMRN", Some("someImporterEORI"), "someEORI", None, dateWithDay3, 1234.56, taxGroups, Some(sMRN)))
 
     override val dailyStatement: CashDailyStatement =
       CashDailyStatement(dateWithDay4, amountZero, amountZero, declarations, Nil)
@@ -159,7 +159,7 @@ class CashTransactionCsvRowSpec extends SpecBase {
   "order the entries correctly within each day" in new Setup {
 
     val declarations: Seq[Declaration] = Seq(Declaration("someMRN", Some("someImporterEORI"), "someEORI",
-      None, LocalDate.of(year2020, month3, day3), 1234.56, Nil))
+      None, LocalDate.of(year2020, month3, day3), 1234.56, Nil, Some(sMRN)))
 
     val expectedTransactionTypes: Seq[Some[String]] = Seq(
       Some("Closing balance"),
@@ -181,6 +181,8 @@ class CashTransactionCsvRowSpec extends SpecBase {
     val topUp: Transaction = Transaction(23.45, Payment, None)
     val transferIn: Transaction = Transaction(23.45, Transfer, None)
     val otherTransactions: Seq[Transaction] = Seq(withdrawal, transferOut, topUp, transferIn)
+
+    val sMRN = "ic62zbad-75fa-445f-962b-cc92311686b8e"
 
     val amountZero = 0.0
 

--- a/test/viewmodels/CashTransactionCsvRowSpec.scala
+++ b/test/viewmodels/CashTransactionCsvRowSpec.scala
@@ -41,9 +41,9 @@ class CashTransactionCsvRowSpec extends SpecBase {
   "generate a declaration row" in new Setup {
 
     val taxGroups: Seq[TaxGroup] = Seq(
-      TaxGroup(ImportVat, -1.23),
-      TaxGroup(CustomsDuty, -2.34),
-      TaxGroup(ExciseDuty, -3.45))
+      TaxGroup(ImportVat, -1.23, taxTypes),
+      TaxGroup(CustomsDuty, -2.34, taxTypes),
+      TaxGroup(ExciseDuty, -3.45, taxTypes))
 
     val declarations: Seq[Declaration] =
       Seq(Declaration("someMRN", Some("someImporterEORI"), "someEORI", None, dateWithDay4, -1234.56, taxGroups, Some(sMRN)))
@@ -176,6 +176,7 @@ class CashTransactionCsvRowSpec extends SpecBase {
   }
 
   trait Setup {
+
     val withdrawal: Transaction = Transaction(-23.45, Withdrawal, None)
     val transferOut: Transaction = Transaction(-23.45, Transfer, None)
     val topUp: Transaction = Transaction(23.45, Payment, None)
@@ -191,9 +192,13 @@ class CashTransactionCsvRowSpec extends SpecBase {
     val day4 = 4
     val day3 = 3
 
+    val fiveHundred: BigDecimal = BigDecimal(500.00)
+
     val dateWithDay3: LocalDate = LocalDate.of(year2020, month3, day3)
     val dateWithDay4: LocalDate = LocalDate.of(year2020, month3, day4)
     val dateForDailyStatement: LocalDate = LocalDate.of(year2020, month3, day4)
+
+    val taxTypes: Seq[TaxType] = Seq(TaxType(reasonForSecurity = "Reason", taxTypeID = "50", amount = fiveHundred))
 
     val dailyStatement: CashDailyStatement =
       CashDailyStatement(dateForDailyStatement, amountZero, amountZero, Nil, Seq(transferIn))

--- a/test/viewmodels/CashTransactionsViewModelSpec.scala
+++ b/test/viewmodels/CashTransactionsViewModelSpec.scala
@@ -33,15 +33,15 @@ class CashTransactionsViewModelSpec extends SpecBase {
       val cashDailyStatementsSortedByDate: Seq[CashDailyStatement] = Seq(
         CashDailyStatement(LocalDate.parse("2020-07-20"), 600.0, 1200.00,
           Seq(Declaration("mrn4", Some("Importer EORI"), "Declarant EORI",
-            Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -90.00, Nil),
+            Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -90.00, Nil, Some(sMRN)),
             Declaration("mrn3", Some("Importer EORI"), "Declarant EORI",
-              Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -30.00, Nil)), Nil),
+              Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -30.00, Nil, Some(sMRN))), Nil),
 
         CashDailyStatement(LocalDate.parse("2020-07-18"), 500.0, 1000.00,
           Seq(Declaration("mrn2", Some("Importer EORI"), "Declarant EORI", None,
-            LocalDate.parse("2020-07-18"), -65.00, Nil),
+            LocalDate.parse("2020-07-18"), -65.00, Nil, Some(sMRN)),
             Declaration("mrn1", Some("Importer EORI"), "Declarant EORI",
-              Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.00, Nil)), Nil))
+              Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.00, Nil, Some(sMRN))), Nil))
 
       model.cashTransactions.cashDailyStatements.sorted mustBe cashDailyStatementsSortedByDate
     }
@@ -51,9 +51,9 @@ class CashTransactionsViewModelSpec extends SpecBase {
 
     val declarationsSortedByMRN: Seq[Declaration] = Seq(
       Declaration("mrn1", Some("Importer EORI"), "Declarant EORI",
-        Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.0, Nil),
+        Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.0, Nil, Some(sMRN)),
       Declaration("mrn2", Some("Importer EORI"), "Declarant EORI",
-        None, LocalDate.parse("2020-07-18"), -65.0, Nil)
+        None, LocalDate.parse("2020-07-18"), -65.0, Nil, Some(sMRN))
     )
 
     model.cashTransactions.cashDailyStatements.head.declarations.sorted mustBe declarationsSortedByMRN
@@ -73,17 +73,17 @@ class CashTransactionsViewModelSpec extends SpecBase {
 
   "CashDailyStatementViewModel" should {
 
-    "calculates the overall size of the collection" in {
-      val someTransactions = Seq(Transaction(123.45, Payment, None),
+    "calculates the overall size of the collection" in new Setup {
+      val someTransactions: Seq[Transaction] = Seq(Transaction(123.45, Payment, None),
         Transaction(223.45, Payment, None),
         Transaction(-54.66, Withdrawal, Some("77665544")),
         Transaction(300.00, Transfer, None),
         Transaction(-300.00, Transfer, None))
 
-      val someDeclarations = Seq(Declaration("mrn1", Some("Importer EORI"),
-        "Declarant EORI", Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.00, Nil))
+      val someDeclarations: Seq[Declaration] = Seq(Declaration("mrn1", Some("Importer EORI"),
+        "Declarant EORI", Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.00, Nil, Some(sMRN)))
 
-      val dailyStatement = CashDailyStatement(
+      val dailyStatement: CashDailyStatement = CashDailyStatement(
         LocalDate.parse("2020-07-20"), 0.0, 0.00, someDeclarations, someTransactions)
 
       dailyStatement.size mustBe 8
@@ -94,49 +94,51 @@ class CashTransactionsViewModelSpec extends SpecBase {
     val mockAppConfig: AppConfig = mock[AppConfig]
     val expectedValue: Int = 5
 
+    val sMRN = "ic62zbad-75fa-445f-962b-cc92311686b8e"
+
     when(mockAppConfig.numberOfDaysToShow).thenReturn(expectedValue)
 
     val cashDailyStatements: Seq[CashDailyStatement] = Seq(
       CashDailyStatement(LocalDate.parse("2020-07-18"), 500.0, 1000.00,
         Seq(Declaration("mrn2", Some("Importer EORI"), "Declarant EORI",
-          None, LocalDate.parse("2020-07-18"), -65.00, Nil),
+          None, LocalDate.parse("2020-07-18"), -65.00, Nil, Some(sMRN)),
           Declaration("mrn1", Some("Importer EORI"), "Declarant EORI",
-            Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.00, Nil)), Nil),
+            Some("Declarant Reference"), LocalDate.parse("2020-07-18"), -84.00, Nil, Some(sMRN))), Nil),
 
       CashDailyStatement(LocalDate.parse("2020-07-20"), 600.0, 1200.00,
         Seq(Declaration("mrn4", Some("Importer EORI"), "Declarant EORI",
-          Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -90.00, Nil),
+          Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -90.00, Nil, Some(sMRN)),
           Declaration("mrn3", Some("Importer EORI"), "Declarant EORI",
-            Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -30.00, Nil)), Nil))
+            Some("Declarant Reference"), LocalDate.parse("2020-07-20"), -30.00, Nil, Some(sMRN))), Nil))
 
     val listOfPendingTransactions: Seq[Declaration] = Seq(
       Declaration("pendingDeclarationID", Some("pendingImporterEORI"),
         "pendingDeclarantEORINumber", Some("pendingDeclarantReference"),
-        LocalDate.parse("2020-08-05"), -300.00, Nil),
+        LocalDate.parse("2020-08-05"), -300.00, Nil, Some(sMRN)),
 
       Declaration("pendingDeclarationID", Some("pendingImporterEORI"),
         "pendingDeclarantEORINumber", Some("pendingDeclarantReference"),
-        LocalDate.parse("2020-07-21"), -100.00, Nil),
+        LocalDate.parse("2020-07-21"), -100.00, Nil, Some(sMRN)),
 
       Declaration("pendingDeclarationID", Some("pendingImporterEORI"),
-        "pendingDeclarantEORINumber", None, LocalDate.parse("2020-07-21"), -50.00, Nil),
+        "pendingDeclarantEORINumber", None, LocalDate.parse("2020-07-21"), -50.00, Nil, Some(sMRN)),
 
       Declaration("pendingDeclarationID", Some("pendingImporterEORI"),
         "pendingDeclarantEORINumber", Some("pendingDeclarantReference"),
-        LocalDate.parse("2020-08-05"), -200.00, Nil)
+        LocalDate.parse("2020-08-05"), -200.00, Nil, Some(sMRN))
     )
 
     val group1: PaginatedPendingDailyStatement = PaginatedPendingDailyStatement(LocalDate.parse("2020-08-05"),
       Seq(Declaration("pendingDeclarationID", Some("pendingImporterEORI"), "pendingDeclarantEORINumber",
-        Some("pendingDeclarantReference"), LocalDate.parse("2020-08-05"), -300.00, Nil),
+        Some("pendingDeclarantReference"), LocalDate.parse("2020-08-05"), -300.00, Nil, Some(sMRN)),
         Declaration("pendingDeclarationID", Some("pendingImporterEORI"), "pendingDeclarantEORINumber",
-          Some("pendingDeclarantReference"), LocalDate.parse("2020-08-05"), -200.00, Nil)))
+          Some("pendingDeclarantReference"), LocalDate.parse("2020-08-05"), -200.00, Nil, Some(sMRN))))
 
     val group2: Seq[Declaration] = Seq(Declaration("pendingDeclarationID", Some("pendingImporterEORI"),
       "pendingDeclarantEORINumber", Some("pendingDeclarantReference"),
-      LocalDate.parse("2020-07-21"), -100.00, Nil), Declaration("pendingDeclarationID",
+      LocalDate.parse("2020-07-21"), -100.00, Nil, Some(sMRN)), Declaration("pendingDeclarationID",
       Some("pendingImporterEORI"), "pendingDeclarantEORINumber", None,
-      LocalDate.parse("2020-07-21"), -50.00, Nil))
+      LocalDate.parse("2020-07-21"), -50.00, Nil, Some(sMRN)))
 
     val cashTransactions: CashTransactions = CashTransactions(listOfPendingTransactions, cashDailyStatements)
     val cashTransactionsWithNoDailyStatement: CashTransactions = CashTransactions(listOfPendingTransactions, Seq.empty)

--- a/test/viewmodels/DeclarationDetailViewModelSpec.scala
+++ b/test/viewmodels/DeclarationDetailViewModelSpec.scala
@@ -18,7 +18,7 @@ package viewmodels
 
 import helpers.Formatters
 import models.domain.EORI
-import models.{CustomsDuty, Declaration, ExciseDuty, ImportVat, TaxGroup}
+import models.{CustomsDuty, Declaration, ExciseDuty, ImportVat, TaxGroup, TaxType}
 import org.mockito.Mockito.*
 import play.api.i18n.{Messages, MessagesApi}
 import uk.gov.hmrc.govukfrontend
@@ -108,9 +108,9 @@ class DeclarationDetailViewModelSpec extends SpecBase {
 
       val declarationWithExcise: Declaration = declaration.copy(
         taxGroups = Seq(
-          TaxGroup(CustomsDuty, fourHundred),
-          TaxGroup(ImportVat, hundred),
-          TaxGroup(ExciseDuty, fifty)
+          TaxGroup(CustomsDuty, fourHundred, taxTypes),
+          TaxGroup(ImportVat, hundred, taxTypes),
+          TaxGroup(ExciseDuty, fifty, taxTypes)
         )
       )
 
@@ -163,6 +163,8 @@ class DeclarationDetailViewModelSpec extends SpecBase {
     val declarantReference: Option[String] = Some("UCR12345")
     val secureMovementReferenceNumber: Option[String] = Some("5a71a767-5c1c-4df8-8eef-2b83769b8fda")
 
+    val taxTypes: Seq[TaxType] = Seq(TaxType(reasonForSecurity = "Reason", taxTypeID = "50", amount = hundred))
+
     val declaration: Declaration = Declaration(
       movementReferenceNumber = movementReferenceNumber,
       importerEori = importerEori,
@@ -171,8 +173,8 @@ class DeclarationDetailViewModelSpec extends SpecBase {
       date = date,
       amount = fiveHundred,
       taxGroups = Seq(
-        TaxGroup(CustomsDuty, fourHundred),
-        TaxGroup(ImportVat, hundred)
+        TaxGroup(CustomsDuty, fourHundred, taxTypes),
+        TaxGroup(ImportVat, hundred, taxTypes)
       ),
       secureMovementReferenceNumber = secureMovementReferenceNumber
     )

--- a/test/viewmodels/DeclarationDetailViewModelSpec.scala
+++ b/test/viewmodels/DeclarationDetailViewModelSpec.scala
@@ -80,7 +80,6 @@ class DeclarationDetailViewModelSpec extends SpecBase {
       extractedResultData must contain allElementsOf expectedTaxData
     }
 
-
     "handle missing optional fields correctly in declarationSummaryList" in new Setup {
 
       val declarationWithMissingFields: Declaration = declaration.copy(
@@ -126,7 +125,6 @@ class DeclarationDetailViewModelSpec extends SpecBase {
 
       extractedResultData must contain((messages("cf.cash-account.csv.excise"), exciseValue))
     }
-
 
     "handle missing excise duty correctly" in new Setup {
 

--- a/test/viewmodels/DeclarationDetailViewModelSpec.scala
+++ b/test/viewmodels/DeclarationDetailViewModelSpec.scala
@@ -26,9 +26,11 @@ import play.twirl.api.{Html, HtmlFormat}
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
+import uk.gov.hmrc.govukfrontend
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
 import views.html.cash_account_declaration_details
 import uk.gov.hmrc.govukfrontend.views
+import uk.gov.hmrc.govukfrontend.views.Aliases
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist
 import utils.SpecBase
 
@@ -104,8 +106,10 @@ class DeclarationDetailViewModelSpec extends SpecBase {
         declarantReference = None
       )
 
-      declarationSummaryList.rows must have size 5
-      val contentMap: Map[String, String] = declarationSummaryList.rows.map(row =>
+      val emptyDeclarationFields: Aliases.SummaryList =
+        DeclarationDetailViewModel.declarationSummaryList(declarationWithMissingFields)(messages)
+
+      val contentMap: Map[String, String] = emptyDeclarationFields.rows.map(row =>
         (row.key.content, row.value.content) match {
           case (Text(key), Text(value)) => (key, value)
           case (Text(key), HtmlContent(value)) => (key, value.body)
@@ -171,8 +175,11 @@ class DeclarationDetailViewModelSpec extends SpecBase {
       secureMovementReferenceNumber = Some("5a71a767-5c1c-4df8-8eef-2b83769b8fda")
     )
 
-    val declarationSummaryList = DeclarationDetailViewModel.declarationSummaryList(declaration)(messages)
-    val taxSummaryList = DeclarationDetailViewModel.taxSummaryList(declaration)(messages)
+    val declarationSummaryList: Aliases.SummaryList =
+      DeclarationDetailViewModel.declarationSummaryList(declaration)(messages)
+
+    val taxSummaryList: govukfrontend.views.Aliases.SummaryList =
+      DeclarationDetailViewModel.taxSummaryList(declaration)(messages)
 
     val viewModel: DeclarationDetailViewModel = DeclarationDetailViewModel("GB326037543470", cashAccount)
 

--- a/test/viewmodels/DeclarationDetailViewModelSpec.scala
+++ b/test/viewmodels/DeclarationDetailViewModelSpec.scala
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels
+
+import models.{AccountStatusOpen, CDSCashBalance, CashAccount, CustomsDuty, Declaration, ImportVat, TaxGroup}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.{Document, Element}
+import org.jsoup.select.Elements
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.*
+import play.twirl.api.{Html, HtmlFormat}
+import play.api.i18n.{Messages, MessagesApi}
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
+import views.html.cash_account_declaration_details
+import uk.gov.hmrc.govukfrontend.views
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist
+import utils.SpecBase
+
+import java.time.LocalDate
+
+class DeclarationDetailViewModelSpec extends SpecBase {
+
+  "DeclarationDetailViewModel" should {
+
+    "generate correct summary lists" in new Setup {
+
+      declarationSummaryList.rows must have size 5
+      declarationSummaryList.rows.map(_.key.content.asInstanceOf[Text].value) must contain allElementsOf Seq(
+        messages("cf.cash-account.csv.date"),
+        messages("cf.cash-account.csv.movementReferenceNumber"),
+        messages("cf.cash-account.csv.uniqueConsignmentReference"),
+        messages("cf.cash-account.csv.declarantEori"),
+        messages("cf.cash-account.csv.importerEori")
+      )
+
+      taxSummaryList.rows must have size 4
+      taxSummaryList.rows.map(_.key.content.asInstanceOf[Text].value) must contain allElementsOf Seq(
+        messages("cf.cash-account.csv.duty"),
+        messages("cf.cash-account.csv.vat"),
+        messages("cf.cash-account.csv.excise"),
+        messages("cf.cash-account.detail.total.paid")
+      )
+    }
+
+    "render the correct declaration and tax details in the view" in new Setup {
+
+      val mockHtml: Html = HtmlFormat.raw(
+        s"""
+        <h2 id="account-number">Account ${cashAccount.number}</h2>
+        <h1>${messages("cf.cash-account.detail.declaration.title")}</h1>
+        <dl class="govuk-summary-list">
+          <dt>${messages("cf.cash-account.csv.date")}</dt>
+          <dt>${messages("cf.cash-account.csv.movementReferenceNumber")}</dt>
+        </dl>
+        <dl class="govuk-summary-list">
+          <dt>${messages("cf.cash-account.csv.duty")}</dt>
+          <dt>${messages("cf.cash-account.csv.vat")}</dt>
+        </dl>
+      """)
+
+      when(view.apply(any(), any(), any())(any(), any())).thenReturn(mockHtml)
+
+      val html: HtmlFormat.Appendable = view.apply(viewModel, declaration, Some(1))(fakeRequest, messages)
+      val document: Document = Jsoup.parse(html.body)
+
+      document.select("h2#account-number").text() must include(cashAccount.number)
+      document.select("h1").text() must include(messages("cf.cash-account.detail.declaration.title"))
+
+      val summaryLists: Elements = document.select(".govuk-summary-list")
+      summaryLists.size() mustBe 2
+
+      val declarationList: Element = summaryLists.first()
+      declarationList.select("dt").eachText() must contain allOf(
+        messages("cf.cash-account.csv.date"),
+        messages("cf.cash-account.csv.movementReferenceNumber")
+      )
+
+      val taxList: Element = summaryLists.last()
+      taxList.select("dt").eachText() must contain allOf(
+        messages("cf.cash-account.csv.duty"),
+        messages("cf.cash-account.csv.vat")
+      )
+    }
+
+    "handle missing optional fields correctly" in new Setup {
+      val declarationWithMissingFields: Declaration = declaration.copy(
+        importerEori = None,
+        declarantReference = None
+      )
+
+      declarationSummaryList.rows must have size 5
+      val contentMap: Map[String, String] = declarationSummaryList.rows.map(row =>
+        (row.key.content, row.value.content) match {
+          case (Text(key), Text(value)) => (key, value)
+          case (Text(key), HtmlContent(value)) => (key, value.body)
+          case _ => fail("Unexpected content type")
+        }).toMap
+
+      contentMap(messages("cf.cash-account.csv.importerEori")) mustBe emptyString
+      contentMap(messages("cf.cash-account.csv.uniqueConsignmentReference")) mustBe emptyString
+    }
+
+    "calculate total tax correctly" in new Setup {
+
+      val totalPaidRow: Option[summarylist.SummaryListRow] = taxSummaryList.rows.find(_.key.content match {
+        case Text(content) => content == messages("cf.cash-account.detail.total.paid")
+        case _ => false
+      })
+      totalPaidRow mustBe defined
+      totalPaidRow.get.value.content match {
+        case Text(content) => content mustBe "£500.00"
+        case HtmlContent(content) => content.body mustBe "£500.00"
+        case _ => fail("Unexpected content type for total paid")
+      }
+    }
+  }
+
+  trait Setup {
+
+    val mockMessagesApi: MessagesApi = mock[MessagesApi]
+    implicit val messages: Messages = mock[Messages]
+
+    when(messages.apply("cf.cash-account.detail.declaration.title")).thenReturn("Declaration Details")
+    when(messages.apply("cf.cash-account.csv.date")).thenReturn("Date")
+    when(messages.apply("cf.cash-account.csv.movementReferenceNumber")).thenReturn("MRN")
+    when(messages.apply("cf.cash-account.csv.uniqueConsignmentReference")).thenReturn("UCR")
+    when(messages.apply("cf.cash-account.csv.declarantEori")).thenReturn("Declarant EORI")
+    when(messages.apply("cf.cash-account.csv.importerEori")).thenReturn("Importer EORI")
+    when(messages.apply("cf.cash-account.csv.duty")).thenReturn("Duty")
+    when(messages.apply("cf.cash-account.csv.vat")).thenReturn("VAT")
+    when(messages.apply("cf.cash-account.csv.excise")).thenReturn("Excise")
+    when(messages.apply("cf.cash-account.detail.total.paid")).thenReturn("Total Paid")
+
+    val fakeRequest: FakeRequest[AnyContentAsEmpty.type] =
+      FakeRequest("GET", "/transaction/5a71a767-5c1c-4df8-8eef-2b83769b8fda")
+
+    val cashAccount: CashAccount = CashAccount(
+      number = "77658497001",
+      owner = "GB Owner",
+      status = AccountStatusOpen,
+      balances = CDSCashBalance(Some(500.00))
+    )
+
+    val declaration: Declaration = Declaration(
+      movementReferenceNumber = "23GB921526241SD4389",
+      importerEori = Some("GB377097541123"),
+      declarantEori = "GB326037543470",
+      declarantReference = Some("Declarant Reference"),
+      date = LocalDate.parse("2024-04-29"),
+      amount = BigDecimal(500.00),
+      taxGroups = Seq(
+        TaxGroup(CustomsDuty, BigDecimal(400.00)),
+        TaxGroup(ImportVat, BigDecimal(100.00))
+      ),
+      secureMovementReferenceNumber = Some("5a71a767-5c1c-4df8-8eef-2b83769b8fda")
+    )
+
+    val declarationSummaryList = DeclarationDetailViewModel.declarationSummaryList(declaration)(messages)
+    val taxSummaryList = DeclarationDetailViewModel.taxSummaryList(declaration)(messages)
+
+    val viewModel: DeclarationDetailViewModel = DeclarationDetailViewModel("GB326037543470", cashAccount)
+
+    val view: cash_account_declaration_details = mock[cash_account_declaration_details]
+  }
+}

--- a/test/viewmodels/DeclarationDetailViewModelSpec.scala
+++ b/test/viewmodels/DeclarationDetailViewModelSpec.scala
@@ -16,173 +16,168 @@
 
 package viewmodels
 
-import models.{AccountStatusOpen, CDSCashBalance, CashAccount, CustomsDuty, Declaration, ImportVat, TaxGroup}
-import org.jsoup.Jsoup
-import org.jsoup.nodes.{Document, Element}
-import org.jsoup.select.Elements
-import org.mockito.ArgumentMatchers.any
+import helpers.Formatters
+import models.domain.EORI
+import models.{CustomsDuty, Declaration, ExciseDuty, ImportVat, TaxGroup}
 import org.mockito.Mockito.*
-import play.twirl.api.{Html, HtmlFormat}
 import play.api.i18n.{Messages, MessagesApi}
-import play.api.mvc.AnyContentAsEmpty
-import play.api.test.FakeRequest
 import uk.gov.hmrc.govukfrontend
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
-import views.html.cash_account_declaration_details
 import uk.gov.hmrc.govukfrontend.views
-import uk.gov.hmrc.govukfrontend.views.Aliases
-import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist
 import utils.SpecBase
 
 import java.time.LocalDate
+import play.api.Application
+import play.api.test.FakeRequest
+import uk.gov
+import uk.gov.hmrc
+import uk.gov.hmrc.govukfrontend.views.Aliases
 
 class DeclarationDetailViewModelSpec extends SpecBase {
 
   "DeclarationDetailViewModel" should {
 
-    "generate correct summary lists" in new Setup {
+    "generate correctly declarationSummaryList data" in new Setup {
 
-      declarationSummaryList.rows must have size 5
-      declarationSummaryList.rows.map(_.key.content.asInstanceOf[Text].value) must contain allElementsOf Seq(
-        messages("cf.cash-account.csv.date"),
-        messages("cf.cash-account.csv.movementReferenceNumber"),
-        messages("cf.cash-account.csv.uniqueConsignmentReference"),
-        messages("cf.cash-account.csv.declarantEori"),
-        messages("cf.cash-account.csv.importerEori")
+      val summaryList: _root_.uk.gov.hmrc.govukfrontend.views.Aliases.SummaryList =
+        DeclarationDetailViewModel.declarationSummaryList(declaration)
+
+      val extractedResultData: Seq[(String, String)] = summaryList.rows.map(row => (
+        row.key.content.asInstanceOf[Text].value,
+        row.value.content.asInstanceOf[HtmlContent].asHtml.toString
+      ))
+
+      val expectedDeclarationSummaryData: Seq[(String, String)] = Seq(
+        (messages("cf.cash-account.csv.date"), Formatters.dateAsDayMonthAndYear(declaration.date)),
+        (messages("cf.cash-account.csv.movementReferenceNumber"), declaration.movementReferenceNumber),
+        (messages("cf.cash-account.csv.uniqueConsignmentReference"), declaration.declarantReference
+          .getOrElse(emptyString)),
+        (messages("cf.cash-account.csv.declarantEori"), declaration.declarantEori),
+        (messages("cf.cash-account.csv.importerEori"), declaration.importerEori.getOrElse(emptyString))
       )
 
-      taxSummaryList.rows must have size 4
-      taxSummaryList.rows.map(_.key.content.asInstanceOf[Text].value) must contain allElementsOf Seq(
-        messages("cf.cash-account.csv.duty"),
-        messages("cf.cash-account.csv.vat"),
-        messages("cf.cash-account.csv.excise"),
-        messages("cf.cash-account.detail.total.paid")
-      )
+      extractedResultData must contain allElementsOf expectedDeclarationSummaryData
     }
 
-    "render the correct declaration and tax details in the view" in new Setup {
 
-      val mockHtml: Html = HtmlFormat.raw(
-        s"""
-        <h2 id="account-number">Account ${cashAccount.number}</h2>
-        <h1>${messages("cf.cash-account.detail.declaration.title")}</h1>
-        <dl class="govuk-summary-list">
-          <dt>${messages("cf.cash-account.csv.date")}</dt>
-          <dt>${messages("cf.cash-account.csv.movementReferenceNumber")}</dt>
-        </dl>
-        <dl class="govuk-summary-list">
-          <dt>${messages("cf.cash-account.csv.duty")}</dt>
-          <dt>${messages("cf.cash-account.csv.vat")}</dt>
-        </dl>
-      """)
+    "generate correctly taxSummaryList data" in new Setup {
 
-      when(view.apply(any(), any(), any())(any(), any())).thenReturn(mockHtml)
+      val summaryList: _root_.uk.gov.hmrc.govukfrontend.views.Aliases.SummaryList =
+        DeclarationDetailViewModel.taxSummaryList(declaration)
 
-      val html: HtmlFormat.Appendable = view.apply(viewModel, declaration, Some(1))(fakeRequest, messages)
-      val document: Document = Jsoup.parse(html.body)
+      val extractedResultData: Seq[(String, String)] = summaryList.rows.map(row => (
+        row.key.content.asInstanceOf[Text].value,
+        row.value.content.asInstanceOf[HtmlContent].asHtml.toString
+      ))
 
-      document.select("h2#account-number").text() must include(cashAccount.number)
-      document.select("h1").text() must include(messages("cf.cash-account.detail.declaration.title"))
-
-      val summaryLists: Elements = document.select(".govuk-summary-list")
-      summaryLists.size() mustBe 2
-
-      val declarationList: Element = summaryLists.first()
-      declarationList.select("dt").eachText() must contain allOf(
-        messages("cf.cash-account.csv.date"),
-        messages("cf.cash-account.csv.movementReferenceNumber")
+      val expectedTaxData: Seq[(String, String)] = Seq(
+        (messages("cf.cash-account.csv.duty"), Formatters.formatCurrencyAmount(fourHundred)),
+        (messages("cf.cash-account.csv.vat"), Formatters.formatCurrencyAmount(hundred)),
+        (messages("cf.cash-account.csv.excise"), emptyString),
+        (messages("cf.cash-account.detail.total.paid"), Formatters.formatCurrencyAmount(fiveHundred))
       )
 
-      val taxList: Element = summaryLists.last()
-      taxList.select("dt").eachText() must contain allOf(
-        messages("cf.cash-account.csv.duty"),
-        messages("cf.cash-account.csv.vat")
-      )
+      extractedResultData must contain allElementsOf expectedTaxData
     }
 
-    "handle missing optional fields correctly" in new Setup {
+
+    "handle missing optional fields correctly in declarationSummaryList" in new Setup {
+
       val declarationWithMissingFields: Declaration = declaration.copy(
         importerEori = None,
         declarantReference = None
       )
 
-      val emptyDeclarationFields: Aliases.SummaryList =
-        DeclarationDetailViewModel.declarationSummaryList(declarationWithMissingFields)(messages)
+      val summaryList: _root_.uk.gov.hmrc.govukfrontend.views.Aliases.SummaryList =
+        DeclarationDetailViewModel.declarationSummaryList(declarationWithMissingFields)
 
-      val contentMap: Map[String, String] = emptyDeclarationFields.rows.map(row =>
-        (row.key.content, row.value.content) match {
-          case (Text(key), Text(value)) => (key, value)
-          case (Text(key), HtmlContent(value)) => (key, value.body)
-          case _ => fail("Unexpected content type")
-        }).toMap
+      val extractedResultData: Seq[(String, String)] = summaryList.rows.map(row => (
+        row.key.content.asInstanceOf[Text].value,
+        row.value.content.asInstanceOf[HtmlContent].asHtml.toString
+      ))
 
-      contentMap(messages("cf.cash-account.csv.importerEori")) mustBe emptyString
-      contentMap(messages("cf.cash-account.csv.uniqueConsignmentReference")) mustBe emptyString
+      val expectedDeclarationSummaryData: Seq[(String, String)] = Seq(
+        (messages("cf.cash-account.csv.importerEori"), emptyString),
+        (messages("cf.cash-account.csv.uniqueConsignmentReference"), emptyString)
+      )
+
+      extractedResultData must contain allElementsOf expectedDeclarationSummaryData
     }
 
-    "calculate total tax correctly" in new Setup {
+    "handle excise duty correctly when present" in new Setup {
 
-      val totalPaidRow: Option[summarylist.SummaryListRow] = taxSummaryList.rows.find(_.key.content match {
-        case Text(content) => content == messages("cf.cash-account.detail.total.paid")
-        case _ => false
-      })
-      totalPaidRow mustBe defined
-      totalPaidRow.get.value.content match {
-        case Text(content) => content mustBe "£500.00"
-        case HtmlContent(content) => content.body mustBe "£500.00"
-        case _ => fail("Unexpected content type for total paid")
-      }
+      val declarationWithExcise: Declaration = declaration.copy(
+        taxGroups = Seq(
+          TaxGroup(CustomsDuty, fourHundred),
+          TaxGroup(ImportVat, hundred),
+          TaxGroup(ExciseDuty, fifty)
+        )
+      )
+
+      val summaryList: _root_.uk.gov.hmrc.govukfrontend.views.Aliases.SummaryList =
+        DeclarationDetailViewModel.taxSummaryList(declarationWithExcise)
+
+      val extractedResultData: Seq[(String, String)] = summaryList.rows.map(row => (
+        row.key.content.asInstanceOf[Text].value,
+        row.value.content.asInstanceOf[HtmlContent].asHtml.toString
+      ))
+
+      val exciseValue: String = Formatters.formatCurrencyAmount(fifty)
+
+      extractedResultData must contain((messages("cf.cash-account.csv.excise"), exciseValue))
+    }
+
+
+    "handle missing excise duty correctly" in new Setup {
+
+      val summaryList: _root_.uk.gov.hmrc.govukfrontend.views.Aliases.SummaryList =
+        DeclarationDetailViewModel.taxSummaryList(declaration)
+
+      val extractedResultData: Seq[(String, String)] = summaryList.rows.map(row => (
+        row.key.content.asInstanceOf[Text].value,
+        row.value.content.asInstanceOf[HtmlContent].asHtml.toString
+      ))
+
+      extractedResultData must contain(messages("cf.cash-account.csv.excise"), emptyString)
     }
   }
 
   trait Setup {
 
-    val mockMessagesApi: MessagesApi = mock[MessagesApi]
-    implicit val messages: Messages = mock[Messages]
+    val year2024 = 2024
+    val month4 = 4
+    val day4 = 29
+    val date: LocalDate = LocalDate.of(year2024, month4, day4)
 
-    when(messages.apply("cf.cash-account.detail.declaration.title")).thenReturn("Declaration Details")
-    when(messages.apply("cf.cash-account.csv.date")).thenReturn("Date")
-    when(messages.apply("cf.cash-account.csv.movementReferenceNumber")).thenReturn("MRN")
-    when(messages.apply("cf.cash-account.csv.uniqueConsignmentReference")).thenReturn("UCR")
-    when(messages.apply("cf.cash-account.csv.declarantEori")).thenReturn("Declarant EORI")
-    when(messages.apply("cf.cash-account.csv.importerEori")).thenReturn("Importer EORI")
-    when(messages.apply("cf.cash-account.csv.duty")).thenReturn("Duty")
-    when(messages.apply("cf.cash-account.csv.vat")).thenReturn("VAT")
-    when(messages.apply("cf.cash-account.csv.excise")).thenReturn("Excise")
-    when(messages.apply("cf.cash-account.detail.total.paid")).thenReturn("Total Paid")
+    val fiveHundred: BigDecimal = BigDecimal(500.00)
+    val fourHundred: BigDecimal = BigDecimal(400.00)
+    val hundred: BigDecimal = BigDecimal(100.00)
+    val fifty: BigDecimal = BigDecimal(50.00)
 
-    val fakeRequest: FakeRequest[AnyContentAsEmpty.type] =
-      FakeRequest("GET", "/transaction/5a71a767-5c1c-4df8-8eef-2b83769b8fda")
-
-    val cashAccount: CashAccount = CashAccount(
-      number = "77658497001",
-      owner = "GB Owner",
-      status = AccountStatusOpen,
-      balances = CDSCashBalance(Some(500.00))
-    )
+    val eori = "GB987654321000"
+    val number = "123456789"
+    val owner = "GB491235123123"
+    val movementReferenceNumber = "MRN1234567890"
+    val importerEori: Option[String] = Some("GB123456789000")
+    val declarantEori = "GB987654321000"
+    val declarantReference: Option[String] = Some("UCR12345")
+    val secureMovementReferenceNumber: Option[String] = Some("5a71a767-5c1c-4df8-8eef-2b83769b8fda")
 
     val declaration: Declaration = Declaration(
-      movementReferenceNumber = "23GB921526241SD4389",
-      importerEori = Some("GB377097541123"),
-      declarantEori = "GB326037543470",
-      declarantReference = Some("Declarant Reference"),
-      date = LocalDate.parse("2024-04-29"),
-      amount = BigDecimal(500.00),
+      movementReferenceNumber = movementReferenceNumber,
+      importerEori = importerEori,
+      declarantEori = declarantEori,
+      declarantReference = declarantReference,
+      date = date,
+      amount = fiveHundred,
       taxGroups = Seq(
-        TaxGroup(CustomsDuty, BigDecimal(400.00)),
-        TaxGroup(ImportVat, BigDecimal(100.00))
+        TaxGroup(CustomsDuty, fourHundred),
+        TaxGroup(ImportVat, hundred)
       ),
-      secureMovementReferenceNumber = Some("5a71a767-5c1c-4df8-8eef-2b83769b8fda")
+      secureMovementReferenceNumber = secureMovementReferenceNumber
     )
 
-    val declarationSummaryList: Aliases.SummaryList =
-      DeclarationDetailViewModel.declarationSummaryList(declaration)(messages)
-
-    val taxSummaryList: govukfrontend.views.Aliases.SummaryList =
-      DeclarationDetailViewModel.taxSummaryList(declaration)(messages)
-
-    val viewModel: DeclarationDetailViewModel = DeclarationDetailViewModel("GB326037543470", cashAccount)
-
-    val view: cash_account_declaration_details = mock[cash_account_declaration_details]
+    val app: Application = application.build()
+    implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
   }
 }

--- a/test/views/CashAccountDeclarationDetailsSpec.scala
+++ b/test/views/CashAccountDeclarationDetailsSpec.scala
@@ -16,7 +16,7 @@
 
 package views
 
-import models.{AccountStatusOpen, CDSCashBalance, CashAccount, CustomsDuty, Declaration, ExciseDuty, ImportVat, TaxGroup}
+import models._
 import viewmodels.DeclarationDetailViewModel
 import views.html.cash_account_declaration_details
 import org.jsoup.Jsoup
@@ -74,6 +74,8 @@ class CashAccountDeclarationDetailsSpec extends ViewTestHelper {
     val declarantEori = "GB987654321000"
     val declarantReference: Option[String] = Some("UCR12345")
 
+    val taxTypes: Seq[TaxType] = Seq(TaxType(reasonForSecurity = "Reason", taxTypeID = "50", amount = fourHundred))
+
     val declaration: Declaration = Declaration(
       movementReferenceNumber = movementReferenceNumber,
       importerEori = importerEori,
@@ -82,9 +84,9 @@ class CashAccountDeclarationDetailsSpec extends ViewTestHelper {
       date = date,
       amount = hundred,
       taxGroups = Seq(
-        TaxGroup(CustomsDuty, fiveHundred),
-        TaxGroup(ImportVat, fourHundred),
-        TaxGroup(ExciseDuty, hundred)
+        TaxGroup(CustomsDuty, fiveHundred, taxTypes),
+        TaxGroup(ImportVat, fourHundred, taxTypes),
+        TaxGroup(ExciseDuty, hundred, taxTypes)
       ),
       secureMovementReferenceNumber = None
     )

--- a/test/views/CashAccountDeclarationDetailsSpec.scala
+++ b/test/views/CashAccountDeclarationDetailsSpec.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import models.{AccountStatusOpen, CDSCashBalance, CashAccount, CustomsDuty, Declaration, ExciseDuty, ImportVat, TaxGroup}
+import viewmodels.DeclarationDetailViewModel
+import views.html.cash_account_declaration_details
+import org.jsoup.Jsoup
+import org.jsoup.nodes.{Document, Element}
+import org.jsoup.select.Elements
+
+import java.time.LocalDate
+
+class CashAccountDeclarationDetailsSpec extends ViewTestHelper {
+
+  "CashAccountDeclarationDetails view" should {
+
+    "render the correct title and headings" in new Setup {
+
+      titleShouldBeCorrect(viewDoc, "cf.cash-account.detail.title")
+
+      viewDoc.getElementsByTag("h1").text() mustBe messages("cf.cash-account.detail.declaration.title")
+
+      val accountNumber = s"${messages("cf.cash-account.detail.account", viewModel.account.number)}"
+
+      viewDoc.getElementById("account-number").text() mustBe accountNumber
+    }
+
+    "have declaration and tax summary lists present" in new Setup {
+
+      val summaryLists: Elements = viewDoc.getElementsByClass("govuk-summary-list")
+      summaryLists.size mustBe 2
+
+      val declarationSummaryList: Element = summaryLists.get(0)
+      declarationSummaryList must not be None
+
+      val taxSummaryList: Element = summaryLists.get(1)
+      taxSummaryList must not be None
+    }
+  }
+
+  trait Setup {
+
+    val year2024 = 2024
+    val month4 = 4
+    val day4 = 4
+    val date: LocalDate = LocalDate.of(year2024, month4, day4)
+
+    val fiveHundred: BigDecimal = BigDecimal(500.00)
+    val fourHundred: BigDecimal = BigDecimal(400.00)
+    val hundred: BigDecimal = BigDecimal(100.00)
+
+    val pageNumber: Option[Int] = Some(1)
+
+    val eori = "GB987654321000"
+    val number = "123456789"
+    val owner = "GB491235123123"
+    val movementReferenceNumber = "MRN1234567890"
+    val importerEori: Option[String] = Some("GB123456789000")
+    val declarantEori = "GB987654321000"
+    val declarantReference: Option[String] = Some("UCR12345")
+
+    val declaration: Declaration = Declaration(
+      movementReferenceNumber = movementReferenceNumber,
+      importerEori = importerEori,
+      declarantEori = declarantEori,
+      declarantReference = declarantReference,
+      date = date,
+      amount = hundred,
+      taxGroups = Seq(
+        TaxGroup(CustomsDuty, fiveHundred),
+        TaxGroup(ImportVat, fourHundred),
+        TaxGroup(ExciseDuty, hundred)
+      ),
+      secureMovementReferenceNumber = None
+    )
+
+    val viewModel: DeclarationDetailViewModel = DeclarationDetailViewModel(
+      eori = eori,
+      account = CashAccount(
+        number = number,
+        owner = owner,
+        status = AccountStatusOpen,
+        balances = CDSCashBalance(Some(fiveHundred))
+      )
+    )
+
+    val cashAccountDeclarationDetails: cash_account_declaration_details =
+      app.injector.instanceOf[cash_account_declaration_details]
+
+    val viewDoc: Document = Jsoup.parse(
+      cashAccountDeclarationDetails.apply(viewModel, declaration, pageNumber)(request, messages).body
+    )
+  }
+}

--- a/test/views/components/H2InnerSpec.scala
+++ b/test/views/components/H2InnerSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.Application
+import play.api.i18n.Messages
+import utils.SpecBase
+import views.html.components.h2Inner
+
+class H2InnerSpec extends SpecBase {
+
+  "H2 component" should {
+
+    "display correct contents" when {
+
+      "it contains msg, innerMsg, id and classes value" in new Setup {
+
+        private val h2InnerComponentAsText = h2InnerComponent.text()
+
+        h2InnerComponentAsText mustBe messages(app)(msgKey, messages(app)(innerMsgKey))
+        h2InnerComponent.select("h2").attr("class") mustBe classesValue
+        h2InnerComponent.select("h2").attr("id") mustBe idValue.get
+      }
+
+      "it does not contain id" in new Setup {
+
+        private val h2InnerComponentWithNoIdAsText = h2InnerComponentWithNoId.text()
+
+        h2InnerComponentWithNoIdAsText mustBe messages(app)(msgKey, messages(app)(innerMsgKey))
+        h2InnerComponentWithNoId.select("h2").attr("class") mustBe classesValue
+        h2InnerComponentWithNoId.select("h2").hasAttr("id") mustBe false
+      }
+
+      "it uses default class" in new Setup {
+
+        private val h2InnerComponentWithDefaultClassAsText = h2InnerComponentWithDefaultClass.text()
+
+        h2InnerComponentWithDefaultClassAsText mustBe messages(app)(msgKey, messages(app)(innerMsgKey))
+        h2InnerComponentWithDefaultClass.select("h2").attr("class") mustBe "govuk-heading-m"
+      }
+
+      "it handles missing inner message" in new Setup {
+
+        private val h2InnerComponentWithEmptyInnerMsgAsText = h2InnerComponentWithEmptyInnerMsg.text()
+
+        h2InnerComponentWithEmptyInnerMsgAsText mustBe messages(app)(msgKey, emptyString)
+        h2InnerComponentWithEmptyInnerMsg.select("h2").attr("class") mustBe classesValue
+        h2InnerComponentWithEmptyInnerMsg.select("h2").hasAttr("id") mustBe false
+      }
+
+      "it handles empty class string" in new Setup {
+
+        private val h2InnerComponentWithEmptyClassAsText = h2InnerComponentWithEmptyClass.text()
+
+        h2InnerComponentWithEmptyClassAsText mustBe messages(app)(msgKey, messages(app)(innerMsgKey))
+        h2InnerComponentWithEmptyClass.select("h2").attr("class") mustBe emptyString
+        h2InnerComponentWithEmptyClass.select("h2").attr("id") mustBe idValue.get
+      }
+    }
+  }
+
+  trait Setup {
+
+    val app: Application = application.build()
+    val msgKey: String = "cf.message"
+    val innerMsgKey: String = "cf.message.inner"
+    val idValue: Option[String] = Some("test-id")
+    val classesValue: String = "govuk-heading-m"
+
+    implicit val msg: Messages = messages(app)
+
+    val h2InnerComponent: Document =
+      Jsoup.parse(app.injector.instanceOf[h2Inner].apply(msgKey, innerMsgKey, idValue, classesValue).body)
+
+    val h2InnerComponentWithNoId: Document =
+      Jsoup.parse(app.injector.instanceOf[h2Inner].apply(msgKey, innerMsgKey, None, classesValue).body)
+
+    val h2InnerComponentWithDefaultClass: Document =
+      Jsoup.parse(app.injector.instanceOf[h2Inner].apply(msgKey, innerMsgKey, idValue).body)
+
+    val h2InnerComponentWithEmptyInnerMsg: Document =
+      Jsoup.parse(app.injector.instanceOf[h2Inner].apply(msgKey, emptyString, None, classesValue).body)
+
+    val h2InnerComponentWithEmptyClass: Document =
+      Jsoup.parse(app.injector.instanceOf[h2Inner].apply(msgKey, innerMsgKey, idValue, emptyString).body)
+  }
+}


### PR DESCRIPTION
Tasks:
- Create a new view for MRN details.
- Fetch MRN details from MongoDB and display.
- Add route.
- Add translation.
- Add unit tests/amend existing ones.

Problem:
- taxGroup is not populated in MongoDB due to how 'customs-financials-api' returns data. Will raise separate fix PR.