### PR TITLE
[MMCA-4955]  Correct spacing between cash account table rows. 

### DIFF
--- a/app/viewmodels/CashAccountDailyStatementsViewModel.scala
+++ b/app/viewmodels/CashAccountDailyStatementsViewModel.scala
@@ -99,6 +99,7 @@ object CashAccountDailyStatementsViewModel {
           transactionType = PaymentType(mrnLink = Some(linkComponent(
             LinkComponentValues(
               linkMessage = Some(declaration.movementReferenceNumber),
+              pWrapped = false,
               location = controllers.routes.DeclarationDetailController.displayDetails(
                 declaration.secureMovementReferenceNumber.getOrElse(emptyString), None).url)
           ))),


### PR DESCRIPTION
[Tasks]
- Removed unnecessary spacing in the table row by disabling the paragraph `<p>` tag that was wrapping the link.
<img width="617" alt="image" src="https://github.com/user-attachments/assets/b9976134-3c5e-4e7a-a2c9-8d50548243a6">
