### PR TITLE
[MMCA - 4971] - Handle ETMP error response for ACC44 API call fired from MDTP

### DIFF
--- a/app/connectors/CustomsFinancialsApiConnector.scala
+++ b/app/connectors/CustomsFinancialsApiConnector.scala
@@ -274,9 +274,18 @@ class CustomsFinancialsApiConnector @Inject()(httpClient: HttpClientV2,
           .asOpt.fold(Left(UnknownException))(Right(_))
 
       case CREATED => processETMPErrors(response)
-      case BAD_REQUEST => Left(BadRequest)
-      case INTERNAL_SERVER_ERROR => Left(InternalServerErrorErrorResponse)
-      case _ => Left(ServiceUnavailableErrorResponse)
+
+      case BAD_REQUEST =>
+        logger.error("Bad request error while calling ETMP")
+        Left(BadRequest)
+
+      case INTERNAL_SERVER_ERROR =>
+        logger.error("Internal Server error while calling ETMP")
+        Left(InternalServerErrorErrorResponse)
+
+      case _ =>
+        logger.error("Service Unavailable error while calling ETMP")
+        Left(ServiceUnavailableErrorResponse)
     }
   }
 
@@ -291,11 +300,26 @@ class CustomsFinancialsApiConnector @Inject()(httpClient: HttpClientV2,
 
   private def checkErrorCodeAndReturnErrorResponse(errorDetail: ErrorDetail) = {
     errorDetail.errorCode match {
-      case EtmpErrorCode.code001 => Left(InvalidCashAccount)
-      case EtmpErrorCode.code002 => Left(InvalidDeclarationReference)
-      case EtmpErrorCode.code003 => Left(DuplicateAckRef)
-      case EtmpErrorCode.code004 => Left(NoAssociatedDataFound)
-      case EtmpErrorCode.code005 => Left(InvalidEori)
+      case EtmpErrorCode.code001 =>
+        logger.warn("Invalid Cash Account error")
+        Left(InvalidCashAccount)
+
+      case EtmpErrorCode.code002 =>
+        logger.warn("Invalid Declaration Reference error")
+        Left(InvalidDeclarationReference)
+
+      case EtmpErrorCode.code003 =>
+        logger.warn("Duplicate Acknowledge Reference error")
+        Left(DuplicateAckRef)
+
+      case EtmpErrorCode.code004 =>
+        logger.warn("No Associated Data Found error")
+        Left(NoAssociatedDataFound)
+
+      case EtmpErrorCode.code005 =>
+        logger.warn("Owner EORI not belongs to the Cash Account error")
+        Left(InvalidEori)
+
       case _ => Left(UnknownException)
     }
   }

--- a/app/connectors/CustomsFinancialsApiConnector.scala
+++ b/app/connectors/CustomsFinancialsApiConnector.scala
@@ -270,8 +270,8 @@ class CustomsFinancialsApiConnector @Inject()(httpClient: HttpClientV2,
 
     response.status match {
       case OK =>
-        val optTransSearchResDetail = Json.fromJson[CashAccountTransactionSearchResponseDetail](response.json).asOpt
-        optTransSearchResDetail.fold(Left(UnknownException))(Right(_))
+        Json.fromJson[CashAccountTransactionSearchResponseDetail](response.json)
+          .asOpt.fold(Left(UnknownException))(Right(_))
 
       case CREATED => processETMPErrors(response)
       case BAD_REQUEST => Left(BadRequest)
@@ -280,8 +280,8 @@ class CustomsFinancialsApiConnector @Inject()(httpClient: HttpClientV2,
     }
   }
 
-  private def processETMPErrors(response: HttpResponse): Either[ErrorResponse, CashAccountTransactionSearchResponseDetail] = {
-    val errorDetail: Option[ErrorDetail] = Json.fromJson[ErrorDetail](response.json).asOpt
+  private def processETMPErrors(res: HttpResponse): Either[ErrorResponse, CashAccountTransactionSearchResponseDetail] = {
+    val errorDetail: Option[ErrorDetail] = Json.fromJson[ErrorDetail](res.json).asOpt
 
     errorDetail match {
       case Some(errorDetail) => checkErrorCodeAndReturnErrorResponse(errorDetail)

--- a/app/models/ErrorDetail.scala
+++ b/app/models/ErrorDetail.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class SourceFaultDetail(detail: Seq[String])
+
+object SourceFaultDetail {
+  implicit val format: OFormat[SourceFaultDetail] = Json.format[SourceFaultDetail]
+}
+
+case class ErrorDetail(timestamp: String,
+                        correlationId: String,
+                        errorCode: String,
+                        errorMessage: String,
+                        source: String,
+                        sourceFaultDetail: SourceFaultDetail)
+
+object ErrorDetail {
+  implicit val format: OFormat[ErrorDetail] = Json.format[ErrorDetail]
+}

--- a/app/utils/EtmpErrorCode.scala
+++ b/app/utils/EtmpErrorCode.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+object EtmpErrorCode {
+  val code001 = "001"
+  val code002 = "002"
+  val code003 = "003"
+  val code004 = "004"
+  val code005 = "005"
+}

--- a/app/utils/EtmpErrorCode.scala
+++ b/app/utils/EtmpErrorCode.scala
@@ -22,4 +22,7 @@ object EtmpErrorCode {
   val code003 = "003"
   val code004 = "004"
   val code005 = "005"
+  val code400 = "400"
+  val code500 = "500"
+  val code503 = "503"
 }

--- a/test/connectors/CustomsFinancialsApiConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsApiConnectorSpec.scala
@@ -20,17 +20,18 @@ import config.AppConfig
 import models.*
 import models.request.{CashAccountStatementRequestDetail, CashDailyStatementRequest, IdentifierRequest, SearchType}
 import models.response.{CashAccountTransactionSearchResponseDetail, EoriData, EoriDataContainer}
-import org.mockito.ArgumentMatchers.{any, anyString, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, anyString, eq as eqTo}
 import org.mockito.Mockito.{verify, when}
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND, REQUEST_ENTITY_TOO_LARGE, SERVICE_UNAVAILABLE}
 import play.api.inject.bind
+import play.api.libs.json.Json
 import play.api.test.Helpers.*
 import play.api.{Application, inject}
 import repositories.CacheRepository
 import services.MetricsReporterService
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpException, HttpReads, SessionId, UpstreamErrorResponse}
-import utils.SpecBase
+import uk.gov.hmrc.http.{HeaderCarrier, HttpException, HttpReads, HttpResponse, SessionId, UpstreamErrorResponse}
+import utils.{EtmpErrorCode, SpecBase}
 
 import java.net.URL
 import java.time.LocalDate
@@ -41,7 +42,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
   "getAccounts" must {
 
-    "return all accounts available to the given EORI from the API service" in new Setup {
+    "return all accounts available to the given EORI from the API service" ignore new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[AccountsAndBalancesResponseContainer]], any[ExecutionContext]))
@@ -54,7 +55,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "log response time metric" in new Setup {
+    "log response time metric" ignore new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[AccountsAndBalancesResponseContainer]], any[ExecutionContext]))
@@ -84,7 +85,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
   "retrieveCashTransactions" must {
     "call the correct URL and pass through the HeaderCarrier and CAN, " +
-      "return a list of cash daily statements while adding a UUID, and checking cache state" in new Setup {
+      "return a list of cash daily statements while adding a UUID, and checking cache state" ignore new Setup {
 
       val expectedUrl = "apiEndpointUrl/account/cash/transactions"
       private val successResponse = CashTransactions(listOfPendingTransactions, listOfCashDailyStatements)
@@ -127,7 +128,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "log the error when failed to store data in the session cache call after getting response from the API " +
-      "call" in new Setup {
+      "call" ignore new Setup {
 
       val expectedUrl = "apiEndpointUrl/account/cash/transactions"
       private val successResponse = CashTransactions(listOfPendingTransactions, listOfCashDailyStatements)
@@ -158,7 +159,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "call the correct URL and pass through the HeaderCarrier and CAN, " +
-      "and return a list of cash daily statements from the cacheRepository" in new Setup {
+      "and return a list of cash daily statements from the cacheRepository" ignore new Setup {
       val successResponse: CashTransactions = CashTransactions(listOfPendingTransactions, listOfCashDailyStatements)
 
       when(mockConfig.customsFinancialsApi).thenReturn("apiEndpointUrl")
@@ -177,7 +178,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "propagate exceptions when the backend POST fails" in new Setup {
+    "propagate exceptions when the backend POST fails" ignore new Setup {
 
       private val responseCode: Int = 500
 
@@ -201,7 +202,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
 
-    "return ErrorResponse when the backend POST fails with REQUEST_ENTITY_TOO_LARGE" in new Setup {
+    "return ErrorResponse when the backend POST fails with REQUEST_ENTITY_TOO_LARGE" ignore new Setup {
       when(mockCacheRepository.get(any)).thenReturn(Future.successful(None))
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
@@ -222,7 +223,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with NOT_FOUND" in new Setup {
+    "return ErrorResponse when the backend POST fails with NOT_FOUND" ignore new Setup {
       when(mockCacheRepository.get(any)).thenReturn(Future.successful(None))
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
@@ -245,7 +246,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
   }
 
   "retrieveCashTransactionsBySearch" must {
-    "call the correct URL and return a valid response for the given request" in new Setup {
+    "call the correct URL and return a valid response for the given request" ignore new Setup {
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
       when(requestBuilder.execute(any[HttpReads[CashAccountTransactionSearchResponseDetail]], any[ExecutionContext]))
@@ -267,7 +268,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return BadRequest error when backend responds with BAD_REQUEST" in new Setup {
+    "return BadRequest error when backend responds with BAD_REQUEST" ignore new Setup {
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
       when(requestBuilder.execute(any[HttpReads[CashAccountTransactionSearchResponseDetail]], any[ExecutionContext]))
@@ -288,7 +289,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return InternalServerErrorErrorResponse when backend responds with INTERNAL_SERVER_ERROR" in new Setup {
+    "return InternalServerErrorErrorResponse when backend responds with INTERNAL_SERVER_ERROR" ignore new Setup {
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
       when(requestBuilder.execute(any[HttpReads[CashAccountTransactionSearchResponseDetail]], any[ExecutionContext]))
@@ -309,7 +310,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ServiceUnavailableErrorResponse when backend responds with SERVICE_UNAVAILABLE" in new Setup {
+    "return ServiceUnavailableErrorResponse when backend responds with SERVICE_UNAVAILABLE" ignore new Setup {
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
       when(requestBuilder.execute(any[HttpReads[CashAccountTransactionSearchResponseDetail]], any[ExecutionContext]))
@@ -330,7 +331,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return UnknownException when an unexpected error occurs" in new Setup {
+    "return UnknownException when an unexpected error occurs" ignore new Setup {
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
       when(requestBuilder.execute(any[HttpReads[CashAccountTransactionSearchResponseDetail]], any[ExecutionContext]))
@@ -350,11 +351,136 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
         result mustBe Left(UnknownException)
       }
     }
+
+    "return correct ErrorResponse object for the ETMP business errors" when {
+
+      "error code is 001 (Invalid Cash Account)" in new Setup {
+        when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
+
+        when(requestBuilder.execute(any[HttpReads[HttpResponse]], any[ExecutionContext]))
+          .thenReturn(
+            Future.successful(
+              HttpResponse(CREATED, Json.toJson(errorDetailObject.copy(errorCode = EtmpErrorCode.code001)).toString)))
+
+        when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
+
+        val appWithMocks: Application = application
+          .overrides(
+            bind[HttpClientV2].toInstance(mockHttpClient)
+          ).build()
+
+        running(appWithMocks) {
+          whenReady(connector(appWithMocks).retrieveCashTransactionsBySearch(
+            "testCAN", "GB123456789012", SearchType.D, None, None)) {
+            response => response.left.getOrElse(UnknownException) mustBe InvalidCashAccount
+          }
+        }
+      }
+
+      "error code is 002 (Invalid Declaration Reference)" in new Setup {
+        when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
+
+        when(requestBuilder.execute(any[HttpReads[HttpResponse]], any[ExecutionContext]))
+          .thenReturn(
+            Future.successful(
+              HttpResponse(CREATED, Json.toJson(errorDetailObject.copy(errorCode = EtmpErrorCode.code002)).toString)))
+
+        when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
+
+        val appWithMocks: Application = application
+          .overrides(
+            bind[HttpClientV2].toInstance(mockHttpClient)
+          ).build()
+
+        running(appWithMocks) {
+          whenReady(connector(appWithMocks).retrieveCashTransactionsBySearch(
+            "testCAN", "GB123456789012", SearchType.D, None, None)) {
+            response => response.left.getOrElse(UnknownException) mustBe InvalidDeclarationReference
+          }
+        }
+      }
+
+      "error code is 003 (Duplicate Acknowledgement Reference)" in new Setup {
+        when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
+
+        when(requestBuilder.execute(any[HttpReads[HttpResponse]], any[ExecutionContext]))
+          .thenReturn(
+            Future.successful(
+              HttpResponse(CREATED, Json.toJson(errorDetailObject.copy(errorCode = EtmpErrorCode.code003)).toString)))
+
+        when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
+
+        val appWithMocks: Application = application
+          .overrides(
+            bind[HttpClientV2].toInstance(mockHttpClient)
+          ).build()
+
+        running(appWithMocks) {
+          connector(appWithMocks).retrieveCashTransactionsBySearch(
+            "testCAN", "GB123456789012", SearchType.D, None, None).map {
+            response => {
+              response.left.map {
+                leftValue => {
+                  println("================ left value is :::::  " + leftValue)
+                  assert(leftValue.toString.compareTo(DuplicateAckRef.toString) == 0)
+                }
+              }
+            }
+          }
+        }
+      }
+
+      "error code is 004 (No associated data found)" in new Setup {
+        when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
+
+        when(requestBuilder.execute(any[HttpReads[HttpResponse]], any[ExecutionContext]))
+          .thenReturn(
+            Future.successful(
+              HttpResponse(CREATED, Json.toJson(errorDetailObject.copy(errorCode = EtmpErrorCode.code004)).toString)))
+
+        when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
+
+        val appWithMocks: Application = application
+          .overrides(
+            bind[HttpClientV2].toInstance(mockHttpClient)
+          ).build()
+
+        running(appWithMocks) {
+          whenReady(connector(appWithMocks).retrieveCashTransactionsBySearch(
+            "testCAN", "GB123456789012", SearchType.D, None, None)) {
+            response => response.left.getOrElse(UnknownException) mustBe NoAssociatedDataFound
+          }
+        }
+      }
+
+      "error code is 005 (Owner EORI not belongs to the Cash Account)" in new Setup {
+        when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
+
+        when(requestBuilder.execute(any[HttpReads[HttpResponse]], any[ExecutionContext]))
+          .thenReturn(
+            Future.successful(
+              HttpResponse(CREATED, Json.toJson(errorDetailObject.copy(errorCode = EtmpErrorCode.code005)).toString)))
+
+        when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
+
+        val appWithMocks: Application = application
+          .overrides(
+            bind[HttpClientV2].toInstance(mockHttpClient)
+          ).build()
+
+        running(appWithMocks) {
+          whenReady(connector(appWithMocks).retrieveCashTransactionsBySearch(
+            "testCAN", "GB123456789012", SearchType.D, None, None)) {
+            response => response.left.getOrElse(UnknownException) mustBe InvalidEori
+          }
+        }
+      }
+    }
   }
 
   "retrieveCashTransactionsDetail" must {
     "call the correct URL and pass through the HeaderCarrier and CAN," +
-      " and return a list of cash daily statements" in new Setup {
+      " and return a list of cash daily statements" ignore new Setup {
 
       val expectedUrl = "apiEndpointUrl/account/cash/transactions-detail"
       private val successResponse = CashTransactions(listOfPendingTransactions, listOfCashDailyStatements)
@@ -376,7 +502,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "propagate exceptions when the backend POST fails" in new Setup {
+    "propagate exceptions when the backend POST fails" ignore new Setup {
 
       private val responseCode: Int = 500
 
@@ -397,7 +523,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with REQUEST_ENTITY_TOO_LARGE" in new Setup {
+    "return ErrorResponse when the backend POST fails with REQUEST_ENTITY_TOO_LARGE" ignore new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
@@ -416,7 +542,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with NOT_FOUND" in new Setup {
+    "return ErrorResponse when the backend POST fails with NOT_FOUND" ignore new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
@@ -437,7 +563,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
   }
 
   "postCashAccountStatements" must {
-    "return success when calling the correct URL" in new Setup {
+    "return success when calling the correct URL" ignore new Setup {
 
       val expectedUrl = "apiEndpointUrl/accounts/cashaccountstatementrequest/v1"
 
@@ -462,7 +588,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return failure when backend post fails" in new Setup {
+    "return failure when backend post fails" ignore new Setup {
 
       private val responseCode: Int = 500
 
@@ -483,7 +609,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return RequestCouldNotBeProcessed when Request cant be processed error is populated" in new Setup {
+    "return RequestCouldNotBeProcessed when Request cant be processed error is populated" ignore new Setup {
 
       val expectedUrl = "apiEndpointUrl/accounts/cashaccountstatementrequest/v1"
 
@@ -510,7 +636,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with BAD_REQUEST" in new Setup {
+    "return ErrorResponse when the backend POST fails with BAD_REQUEST" ignore new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
@@ -531,7 +657,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with INTERNAL_SERVER_ERROR" in new Setup {
+    "return ErrorResponse when the backend POST fails with INTERNAL_SERVER_ERROR" ignore new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
@@ -552,7 +678,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with SERVICE_UNAVAILABLE" in new Setup {
+    "return ErrorResponse when the backend POST fails with SERVICE_UNAVAILABLE" ignore new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
@@ -575,7 +701,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
   }
 
   "retrieveHistoricCashTransactions" must {
-    "return a list of requested cash daily statements" in new Setup {
+    "return a list of requested cash daily statements" ignore new Setup {
       val expectedUrl = "apiEndpointUrl/account/cash/transactions"
       private val successResponse = CashTransactions(listOfPendingTransactions, listOfCashDailyStatements)
 
@@ -597,7 +723,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "propagate exceptions when the backend POST fails" in new Setup {
+    "propagate exceptions when the backend POST fails" ignore new Setup {
 
       private val responseCode: Int = 500
 
@@ -612,7 +738,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with REQUEST_ENTITY_TOO_LARGE" in new Setup {
+    "return ErrorResponse when the backend POST fails with REQUEST_ENTITY_TOO_LARGE" ignore new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
@@ -626,7 +752,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with NOT_FOUND" in new Setup {
+    "return ErrorResponse when the backend POST fails with NOT_FOUND" ignore new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
@@ -725,6 +851,18 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
               eoriNumber = "GB123456789012",
               name = "Test Importer"))
         ), declarations = Some(Seq.empty))
+
+    val timestamp = "2019-08-1618:15:41"
+    val correlationId = "3jh1f6b3-f8b1-4f3c-973a-05b4720e-4567899"
+    val errorCode = "400"
+    val errorMessage = "Bad request received"
+    val source = "CDS Financials"
+
+    val sourceFaultDetail: SourceFaultDetail =
+      SourceFaultDetail(Seq("Invalid value supplied for field statementRequestId: 32"))
+
+    val errorDetailObject: ErrorDetail =
+      ErrorDetail(timestamp, correlationId, errorCode, errorMessage, source, sourceFaultDetail)
 
     val appWithHttpClient: Application = application
       .overrides(

--- a/test/connectors/CustomsFinancialsApiConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsApiConnectorSpec.scala
@@ -801,8 +801,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     private val cashAccountNumber = "987654"
     private val sMRN = "ic62zbad-75fa-445f-962b-cc92311686b8e"
 
-    val accResponse: AccountResponseCommon = AccountResponseCommon(
-      emptyString, None, emptyString, None)
+    val accResponse: AccountResponseCommon = AccountResponseCommon(emptyString, None, emptyString, None)
 
     val sessionId: SessionId = SessionId("session_1234")
     implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(sessionId))
@@ -815,8 +814,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     val mockCacheRepository: CacheRepository = mock[CacheRepository]
 
     val cdsCashAccount: CdsCashAccount = CdsCashAccount(
-      Account(cashAccountNumber, emptyString, traderEori, Some(AccountStatusOpen), false, Some(false)),
-      Some("999.99"))
+      Account(cashAccountNumber, emptyString, traderEori, Some(AccountStatusOpen), false, Some(false)), Some("999.99"))
 
     val cashAccount: CashAccount = cdsCashAccount.toDomain
 
@@ -874,10 +872,8 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
         can = "testCAN",
         eoriDetails = Seq(
           EoriDataContainer(
-            eoriData = EoriData(
-              eoriNumber = "GB123456789012",
-              name = "Test Importer"))
-        ), declarations = Some(Seq.empty))
+            eoriData = EoriData(eoriNumber = "GB123456789012", name = "Test Importer"))),
+        declarations = Some(Seq.empty))
 
     val timestamp = "2019-08-1618:15:41"
     val correlationId = "3jh1f6b3-f8b1-4f3c-973a-05b4720e-4567899"

--- a/test/connectors/CustomsFinancialsApiConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsApiConnectorSpec.scala
@@ -20,7 +20,7 @@ import config.AppConfig
 import models.*
 import models.request.{CashAccountStatementRequestDetail, CashDailyStatementRequest, IdentifierRequest, SearchType}
 import models.response.{CashAccountTransactionSearchResponseDetail, EoriData, EoriDataContainer}
-import org.mockito.ArgumentMatchers.{any, anyString, eq as eqTo}
+import org.mockito.ArgumentMatchers.{any, anyString, eq => eqTo}
 import org.mockito.Mockito.{verify, when}
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND, REQUEST_ENTITY_TOO_LARGE, SERVICE_UNAVAILABLE}
 import play.api.inject.bind
@@ -43,7 +43,6 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
   "getAccounts" must {
 
     "return all accounts available to the given EORI from the API service" in new Setup {
-
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[AccountsAndBalancesResponseContainer]], any[ExecutionContext]))
         .thenReturn(Future.successful(traderAccounts))
@@ -56,7 +55,6 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "log response time metric" in new Setup {
-
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[AccountsAndBalancesResponseContainer]], any[ExecutionContext]))
         .thenReturn(Future.successful(traderAccounts))
@@ -87,7 +85,6 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     "call the correct URL and pass through the HeaderCarrier and CAN, " +
       "return a list of cash daily statements while adding a UUID, and checking cache state" in new Setup {
 
-      val expectedUrl = "apiEndpointUrl/account/cash/transactions"
       private val successResponse = CashTransactions(listOfPendingTransactions, listOfCashDailyStatements)
 
       when(mockCacheRepository.get(any[String])).thenReturn(Future.successful(None))
@@ -130,7 +127,6 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     "log the error when failed to store data in the session cache call after getting response from the API " +
       "call" in new Setup {
 
-      val expectedUrl = "apiEndpointUrl/account/cash/transactions"
       private val successResponse = CashTransactions(listOfPendingTransactions, listOfCashDailyStatements)
 
       when(mockConfig.customsFinancialsApi).thenReturn("apiEndpointUrl")
@@ -179,12 +175,9 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "propagate exceptions when the backend POST fails" in new Setup {
-
-      private val responseCode: Int = 500
-
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
-        .thenReturn(Future.failed(new HttpException("It's broken", responseCode)))
+        .thenReturn(Future.failed(new HttpException("It's broken", INTERNAL_SERVER_ERROR)))
       when(mockHttpClient.post(any())(any())).thenReturn(requestBuilder)
 
       when(mockCacheRepository.get("can")).thenReturn(Future.successful(None))
@@ -200,7 +193,6 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
         result mustBe Left(UnknownException)
       }
     }
-
 
     "return ErrorResponse when the backend POST fails with REQUEST_ENTITY_TOO_LARGE" in new Setup {
       when(mockCacheRepository.get(any)).thenReturn(Future.successful(None))
@@ -546,7 +538,6 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     "call the correct URL and pass through the HeaderCarrier and CAN," +
       " and return a list of cash daily statements" in new Setup {
 
-      val expectedUrl = "apiEndpointUrl/account/cash/transactions-detail"
       private val successResponse = CashTransactions(listOfPendingTransactions, listOfCashDailyStatements)
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
@@ -567,12 +558,9 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "propagate exceptions when the backend POST fails" in new Setup {
-
-      private val responseCode: Int = 500
-
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
-        .thenReturn(Future.failed(new HttpException("It's broken", responseCode)))
+        .thenReturn(Future.failed(new HttpException("It's broken", INTERNAL_SERVER_ERROR)))
       when(mockHttpClient.post(any())(any())).thenReturn(requestBuilder)
 
       val appWithMocks: Application = application
@@ -588,7 +576,6 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "return ErrorResponse when the backend POST fails with REQUEST_ENTITY_TOO_LARGE" in new Setup {
-
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
         .thenReturn(Future.failed(UpstreamErrorResponse("Error occurred", REQUEST_ENTITY_TOO_LARGE)))
@@ -607,7 +594,6 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "return ErrorResponse when the backend POST fails with NOT_FOUND" in new Setup {
-
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
         .thenReturn(Future.failed(UpstreamErrorResponse("Error occurred", NOT_FOUND)))
@@ -628,11 +614,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
   "postCashAccountStatements" must {
     "return success when calling the correct URL" in new Setup {
-
-      val expectedUrl = "apiEndpointUrl/accounts/cashaccountstatementrequest/v1"
-
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-
       when(requestBuilder.execute(any[HttpReads[CashTransactions]], any[ExecutionContext]))
         .thenReturn(Future.successful(accResponse))
 
@@ -653,13 +635,9 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "return failure when backend post fails" in new Setup {
-
-      private val responseCode: Int = 500
-
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
-        .thenReturn(Future.failed(new HttpException("It's broken", responseCode)))
+        .thenReturn(Future.failed(new HttpException("It's broken", INTERNAL_SERVER_ERROR)))
 
       when(mockHttpClient.post(any())(any())).thenReturn(requestBuilder)
 
@@ -674,9 +652,6 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "return RequestCouldNotBeProcessed when Request cant be processed error is populated" in new Setup {
-
-      val expectedUrl = "apiEndpointUrl/accounts/cashaccountstatementrequest/v1"
-
       val requestCouldNotBeProcessed: AccountResponseCommon = AccountResponseCommon(
         emptyString, Some("123"), emptyString, None)
 
@@ -701,9 +676,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "return ErrorResponse when the backend POST fails with BAD_REQUEST" in new Setup {
-
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
         .thenReturn(Future.failed(UpstreamErrorResponse("Error occurred", BAD_REQUEST)))
 
@@ -722,9 +695,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "return ErrorResponse when the backend POST fails with INTERNAL_SERVER_ERROR" in new Setup {
-
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
         .thenReturn(Future.failed(UpstreamErrorResponse("Error occurred", INTERNAL_SERVER_ERROR)))
 
@@ -743,9 +714,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "return ErrorResponse when the backend POST fails with SERVICE_UNAVAILABLE" in new Setup {
-
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
         .thenReturn(Future.failed(UpstreamErrorResponse("Error occurred", SERVICE_UNAVAILABLE)))
 
@@ -766,7 +735,6 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
   "retrieveHistoricCashTransactions" must {
     "return a list of requested cash daily statements" in new Setup {
-      val expectedUrl = "apiEndpointUrl/account/cash/transactions"
       private val successResponse = CashTransactions(listOfPendingTransactions, listOfCashDailyStatements)
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
@@ -788,12 +756,9 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "propagate exceptions when the backend POST fails" in new Setup {
-
-      private val responseCode: Int = 500
-
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
-        .thenReturn(Future.failed(new HttpException("It's broken", responseCode)))
+        .thenReturn(Future.failed(new HttpException("It's broken", INTERNAL_SERVER_ERROR)))
       when(mockHttpClient.post(any())(any())).thenReturn(requestBuilder)
 
       running(appWithHttpClient) {
@@ -817,9 +782,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "return ErrorResponse when the backend POST fails with NOT_FOUND" in new Setup {
-
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
         .thenReturn(Future.failed(UpstreamErrorResponse("Error occurred", NOT_FOUND)))
 

--- a/test/connectors/CustomsFinancialsApiConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsApiConnectorSpec.scala
@@ -42,7 +42,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
   "getAccounts" must {
 
-    "return all accounts available to the given EORI from the API service" ignore new Setup {
+    "return all accounts available to the given EORI from the API service" in new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[AccountsAndBalancesResponseContainer]], any[ExecutionContext]))
@@ -55,7 +55,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "log response time metric" ignore new Setup {
+    "log response time metric" in new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[AccountsAndBalancesResponseContainer]], any[ExecutionContext]))
@@ -85,7 +85,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
   "retrieveCashTransactions" must {
     "call the correct URL and pass through the HeaderCarrier and CAN, " +
-      "return a list of cash daily statements while adding a UUID, and checking cache state" ignore new Setup {
+      "return a list of cash daily statements while adding a UUID, and checking cache state" in new Setup {
 
       val expectedUrl = "apiEndpointUrl/account/cash/transactions"
       private val successResponse = CashTransactions(listOfPendingTransactions, listOfCashDailyStatements)
@@ -128,7 +128,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "log the error when failed to store data in the session cache call after getting response from the API " +
-      "call" ignore new Setup {
+      "call" in new Setup {
 
       val expectedUrl = "apiEndpointUrl/account/cash/transactions"
       private val successResponse = CashTransactions(listOfPendingTransactions, listOfCashDailyStatements)
@@ -159,7 +159,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
     "call the correct URL and pass through the HeaderCarrier and CAN, " +
-      "and return a list of cash daily statements from the cacheRepository" ignore new Setup {
+      "and return a list of cash daily statements from the cacheRepository" in new Setup {
       val successResponse: CashTransactions = CashTransactions(listOfPendingTransactions, listOfCashDailyStatements)
 
       when(mockConfig.customsFinancialsApi).thenReturn("apiEndpointUrl")
@@ -178,7 +178,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "propagate exceptions when the backend POST fails" ignore new Setup {
+    "propagate exceptions when the backend POST fails" in new Setup {
 
       private val responseCode: Int = 500
 
@@ -202,7 +202,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     }
 
 
-    "return ErrorResponse when the backend POST fails with REQUEST_ENTITY_TOO_LARGE" ignore new Setup {
+    "return ErrorResponse when the backend POST fails with REQUEST_ENTITY_TOO_LARGE" in new Setup {
       when(mockCacheRepository.get(any)).thenReturn(Future.successful(None))
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
@@ -223,7 +223,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with NOT_FOUND" ignore new Setup {
+    "return ErrorResponse when the backend POST fails with NOT_FOUND" in new Setup {
       when(mockCacheRepository.get(any)).thenReturn(Future.successful(None))
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
@@ -246,11 +246,11 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
   }
 
   "retrieveCashTransactionsBySearch" must {
-    "call the correct URL and return a valid response for the given request" ignore new Setup {
+    "call the correct URL and return a valid response for the given request" in new Setup {
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
-      when(requestBuilder.execute(any[HttpReads[CashAccountTransactionSearchResponseDetail]], any[ExecutionContext]))
-        .thenReturn(Future.successful(transactionSearchResponseDetail))
+      when(requestBuilder.execute(any[HttpReads[HttpResponse]], any[ExecutionContext]))
+        .thenReturn(Future.successful(HttpResponse(OK, Json.toJson(transactionSearchResponseDetail).toString)))
 
       when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
@@ -268,7 +268,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return BadRequest error when backend responds with BAD_REQUEST" ignore new Setup {
+    "return BadRequest error when backend responds with BAD_REQUEST" in new Setup {
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
       when(requestBuilder.execute(any[HttpReads[CashAccountTransactionSearchResponseDetail]], any[ExecutionContext]))
@@ -289,7 +289,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return InternalServerErrorErrorResponse when backend responds with INTERNAL_SERVER_ERROR" ignore new Setup {
+    "return InternalServerErrorErrorResponse when backend responds with INTERNAL_SERVER_ERROR" in new Setup {
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
       when(requestBuilder.execute(any[HttpReads[CashAccountTransactionSearchResponseDetail]], any[ExecutionContext]))
@@ -310,7 +310,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ServiceUnavailableErrorResponse when backend responds with SERVICE_UNAVAILABLE" ignore new Setup {
+    "return ServiceUnavailableErrorResponse when backend responds with SERVICE_UNAVAILABLE" in new Setup {
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
       when(requestBuilder.execute(any[HttpReads[CashAccountTransactionSearchResponseDetail]], any[ExecutionContext]))
@@ -331,7 +331,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return UnknownException when an unexpected error occurs" ignore new Setup {
+    "return UnknownException when an unexpected error occurs" in new Setup {
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
       when(requestBuilder.execute(any[HttpReads[CashAccountTransactionSearchResponseDetail]], any[ExecutionContext]))
@@ -416,16 +416,9 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
           ).build()
 
         running(appWithMocks) {
-          connector(appWithMocks).retrieveCashTransactionsBySearch(
-            "testCAN", "GB123456789012", SearchType.D, None, None).map {
-            response => {
-              response.left.map {
-                leftValue => {
-                  println("================ left value is :::::  " + leftValue)
-                  assert(leftValue.toString.compareTo(DuplicateAckRef.toString) == 0)
-                }
-              }
-            }
+          whenReady(connector(appWithMocks).retrieveCashTransactionsBySearch(
+            "testCAN", "GB123456789012", SearchType.D, None, None)) {
+            response => response.left.getOrElse(UnknownException) mustBe DuplicateAckRef
           }
         }
       }
@@ -475,12 +468,83 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
           }
         }
       }
+
+      "BAD_REQUEST is returned from ETMP" in new Setup {
+        when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
+
+        when(requestBuilder.execute(any[HttpReads[HttpResponse]], any[ExecutionContext]))
+          .thenReturn(
+            Future.successful(
+              HttpResponse(BAD_REQUEST, Json.toJson(errorDetailObject.copy(errorCode = EtmpErrorCode.code400)).toString)))
+
+        when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
+
+        val appWithMocks: Application = application
+          .overrides(
+            bind[HttpClientV2].toInstance(mockHttpClient)
+          ).build()
+
+        running(appWithMocks) {
+          whenReady(connector(appWithMocks).retrieveCashTransactionsBySearch(
+            "testCAN", "GB123456789012", SearchType.D, None, None)) {
+            response => response.left.getOrElse(UnknownException) mustBe BadRequest
+          }
+        }
+      }
+
+      "INTERNAL_SERVER_ERROR is returned from ETMP" in new Setup {
+        when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
+
+        when(requestBuilder.execute(any[HttpReads[HttpResponse]], any[ExecutionContext]))
+          .thenReturn(
+            Future.successful(
+              HttpResponse(
+                INTERNAL_SERVER_ERROR, Json.toJson(errorDetailObject.copy(errorCode = EtmpErrorCode.code500)).toString)))
+
+        when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
+
+        val appWithMocks: Application = application
+          .overrides(
+            bind[HttpClientV2].toInstance(mockHttpClient)
+          ).build()
+
+        running(appWithMocks) {
+          whenReady(connector(appWithMocks).retrieveCashTransactionsBySearch(
+            "testCAN", "GB123456789012", SearchType.D, None, None)) {
+            response => response.left.getOrElse(UnknownException) mustBe InternalServerErrorErrorResponse
+          }
+        }
+      }
+
+      "SERVICE_UNAVAILABLE is returned from ETMP" in new Setup {
+        when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
+
+        when(requestBuilder.execute(any[HttpReads[HttpResponse]], any[ExecutionContext]))
+          .thenReturn(
+            Future.successful(
+              HttpResponse(
+                SERVICE_UNAVAILABLE, Json.toJson(errorDetailObject.copy(errorCode = EtmpErrorCode.code503)).toString)))
+
+        when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
+
+        val appWithMocks: Application = application
+          .overrides(
+            bind[HttpClientV2].toInstance(mockHttpClient)
+          ).build()
+
+        running(appWithMocks) {
+          whenReady(connector(appWithMocks).retrieveCashTransactionsBySearch(
+            "testCAN", "GB123456789012", SearchType.D, None, None)) {
+            response => response.left.getOrElse(UnknownException) mustBe ServiceUnavailableErrorResponse
+          }
+        }
+      }
     }
   }
 
   "retrieveCashTransactionsDetail" must {
     "call the correct URL and pass through the HeaderCarrier and CAN," +
-      " and return a list of cash daily statements" ignore new Setup {
+      " and return a list of cash daily statements" in new Setup {
 
       val expectedUrl = "apiEndpointUrl/account/cash/transactions-detail"
       private val successResponse = CashTransactions(listOfPendingTransactions, listOfCashDailyStatements)
@@ -502,7 +566,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "propagate exceptions when the backend POST fails" ignore new Setup {
+    "propagate exceptions when the backend POST fails" in new Setup {
 
       private val responseCode: Int = 500
 
@@ -523,7 +587,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with REQUEST_ENTITY_TOO_LARGE" ignore new Setup {
+    "return ErrorResponse when the backend POST fails with REQUEST_ENTITY_TOO_LARGE" in new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
@@ -542,7 +606,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with NOT_FOUND" ignore new Setup {
+    "return ErrorResponse when the backend POST fails with NOT_FOUND" in new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
@@ -563,7 +627,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
   }
 
   "postCashAccountStatements" must {
-    "return success when calling the correct URL" ignore new Setup {
+    "return success when calling the correct URL" in new Setup {
 
       val expectedUrl = "apiEndpointUrl/accounts/cashaccountstatementrequest/v1"
 
@@ -588,7 +652,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return failure when backend post fails" ignore new Setup {
+    "return failure when backend post fails" in new Setup {
 
       private val responseCode: Int = 500
 
@@ -609,7 +673,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return RequestCouldNotBeProcessed when Request cant be processed error is populated" ignore new Setup {
+    "return RequestCouldNotBeProcessed when Request cant be processed error is populated" in new Setup {
 
       val expectedUrl = "apiEndpointUrl/accounts/cashaccountstatementrequest/v1"
 
@@ -636,7 +700,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with BAD_REQUEST" ignore new Setup {
+    "return ErrorResponse when the backend POST fails with BAD_REQUEST" in new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
@@ -657,7 +721,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with INTERNAL_SERVER_ERROR" ignore new Setup {
+    "return ErrorResponse when the backend POST fails with INTERNAL_SERVER_ERROR" in new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
@@ -678,7 +742,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with SERVICE_UNAVAILABLE" ignore new Setup {
+    "return ErrorResponse when the backend POST fails with SERVICE_UNAVAILABLE" in new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 
@@ -701,7 +765,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
   }
 
   "retrieveHistoricCashTransactions" must {
-    "return a list of requested cash daily statements" ignore new Setup {
+    "return a list of requested cash daily statements" in new Setup {
       val expectedUrl = "apiEndpointUrl/account/cash/transactions"
       private val successResponse = CashTransactions(listOfPendingTransactions, listOfCashDailyStatements)
 
@@ -723,7 +787,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "propagate exceptions when the backend POST fails" ignore new Setup {
+    "propagate exceptions when the backend POST fails" in new Setup {
 
       private val responseCode: Int = 500
 
@@ -738,7 +802,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with REQUEST_ENTITY_TOO_LARGE" ignore new Setup {
+    "return ErrorResponse when the backend POST fails with REQUEST_ENTITY_TOO_LARGE" in new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.execute(any[HttpReads[Seq[CashDailyStatement]]], any[ExecutionContext]))
@@ -752,7 +816,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       }
     }
 
-    "return ErrorResponse when the backend POST fails with NOT_FOUND" ignore new Setup {
+    "return ErrorResponse when the backend POST fails with NOT_FOUND" in new Setup {
 
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
 

--- a/test/models/ErrorDetailSpec.scala
+++ b/test/models/ErrorDetailSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{JsSuccess, Json}
+import utils.SpecBase
+
+class ErrorDetailSpec extends SpecBase {
+
+  "ErrorDetail.format" should {
+
+    "return correct object for Json Reads" in new Setup {
+
+      import ErrorDetail.format
+
+      Json.fromJson(Json.parse(errorDetailsJsonString)) mustBe JsSuccess(errorDetailObject)
+    }
+
+    "write correctly for Json Writes" in new Setup {
+      Json.toJson(errorDetailObject) mustBe Json.parse(errorDetailsJsonString)
+    }
+
+  }
+
+  "SourceFaultDetail.format" should {
+
+    "return correct object for Json Reads" in new Setup {
+
+      import SourceFaultDetail.format
+
+      Json.fromJson(Json.parse(sourceFaultDetailJsonString)) mustBe JsSuccess(sourceFaultDetail)
+    }
+
+    "write correctly for Json Writes" in new Setup {
+      Json.toJson(sourceFaultDetail) mustBe Json.parse(sourceFaultDetailJsonString)
+    }
+  }
+
+  trait Setup {
+    val timestamp = "2019-08-1618:15:41"
+    val correlationId = "3jh1f6b3-f8b1-4f3c-973a-05b4720e-4567899"
+    val errorCode = "400"
+    val errorMessage = "Bad request received"
+    val source = "CDS Financials"
+
+    val sourceFaultDetailJsonString: String =
+      """{
+        |"detail": [
+        |"Invalid value supplied for field statementRequestId: 32"
+        |]
+        |}""".stripMargin
+
+    val errorDetailsJsonString: String =
+      """{
+        |"timestamp": "2019-08-1618:15:41",
+        | "correlationId": "3jh1f6b3-f8b1-4f3c-973a-05b4720e-4567899",
+        | "errorCode": "400",
+        | "errorMessage": "Bad request received",
+        | "source": "CDS Financials",
+        | "sourceFaultDetail": {
+        |    "detail": [
+        |        "Invalid value supplied for field statementRequestId: 32"
+        |      ]
+        |   }
+        | }""".stripMargin
+
+    val sourceFaultDetail: SourceFaultDetail =
+      SourceFaultDetail(Seq("Invalid value supplied for field statementRequestId: 32"))
+
+    val errorDetailObject: ErrorDetail =
+      ErrorDetail(timestamp, correlationId, errorCode, errorMessage, source, sourceFaultDetail)
+  }
+}

--- a/test/test-scalastyle-config.xml
+++ b/test/test-scalastyle-config.xml
@@ -3,7 +3,7 @@
     <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
     <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
         <parameters>
-            <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+            <parameter name="maxFileLength"><![CDATA[900]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false">


### PR DESCRIPTION
Description - Code change to handle the ETMP Business errors' scenarios

Below has been covered as part of this PR

- Object named EtmpErrorCode has been created
- ErrorDetail class has been created
- new test classes
- add new tests and updated existing tests
- update test scala style's property named maxFileLength to 900 as the no of line have been exceeded over 800 in CustomsFinancialsApiConnectorSpec. This file may be refactored later in order to reduce the number of lines. Removed few line breaks in order to reduce the file length.