### PR TITLE
MMCA-4980 | Retrieve the registered email address to display on cash account transaction request confirmation page

### DIFF
--- a/app/controllers/ConfirmationPageController.scala
+++ b/app/controllers/ConfirmationPageController.scala
@@ -64,7 +64,7 @@ class ConfirmationPageController @Inject()(override val messagesApi: MessagesApi
 
       result.recover {
         case e: Exception =>
-          log.error(s"filed to load ConfirmationPageController $e")
+          log.error(s"Failed to load ConfirmationPageController $e")
           Redirect(routes.CashAccountController.showAccountUnavailable)
       }
   }
@@ -81,7 +81,7 @@ class ConfirmationPageController @Inject()(override val messagesApi: MessagesApi
         Ok(view(s"$startDate ${messages("month.to")} $endDate", email))
 
       case _ =>
-        log.error(s"filed to load checkDatesAndRedirect $optionalDates")
+        log.error(s"Failed to load checkDatesAndEmailAndRedirect $optionalDates")
         Redirect(routes.CashAccountController.showAccountUnavailable)
     }
   }

--- a/app/controllers/ConfirmationPageController.scala
+++ b/app/controllers/ConfirmationPageController.scala
@@ -55,10 +55,8 @@ class ConfirmationPageController @Inject()(override val messagesApi: MessagesApi
         email <- customsDataStoreConnector.getEmail(request.eori)
       } yield {
         email match {
-          case Right(email) =>
-            checkDatesAndEmailAndRedirect(dates, email.value)
-          case Left(_) =>
-            checkDatesAndEmailAndRedirect(dates, emptyString)
+          case Right(email) => checkDatesAndEmailAndRedirect(dates, Some(email.value))
+          case Left(_) => checkDatesAndEmailAndRedirect(dates, None)
         }
       }
 
@@ -69,7 +67,7 @@ class ConfirmationPageController @Inject()(override val messagesApi: MessagesApi
       }
   }
 
-  private def checkDatesAndEmailAndRedirect(optionalDates: Option[CashTransactionDates], email: String)
+  private def checkDatesAndEmailAndRedirect(optionalDates: Option[CashTransactionDates], email: Option[String])
                                            (implicit request: IdentifierRequest[AnyContent],
                                             messages: Messages): Result = {
     optionalDates match {

--- a/app/controllers/ConfirmationPageController.scala
+++ b/app/controllers/ConfirmationPageController.scala
@@ -17,16 +17,16 @@
 package controllers
 
 import config.AppConfig
-import controllers.actions.*
+import connectors.CustomsDataStoreConnector
+import controllers.actions.IdentifierAction
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.auth.core.retrieve.Email
-import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.bootstrap.frontend.controller.{FrontendBaseController, FrontendController}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils.Utils.emptyString
 import repositories.RequestedTransactionsCache
 import views.html.confirmation_page
-import helpers.Formatters.{dateAsDayMonthAndYear, dateAsMonthAndYear}
+import helpers.Formatters.dateAsMonthAndYear
 import models.CashTransactionDates
 import play.api.i18n.Messages
 import models.request.IdentifierRequest
@@ -34,12 +34,12 @@ import play.api.Logger
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
-import java.time.LocalDate
 
 class ConfirmationPageController @Inject()(override val messagesApi: MessagesApi,
                                            identify: IdentifierAction,
                                            cache: RequestedTransactionsCache,
-                                           view: confirmation_page)
+                                           view: confirmation_page,
+                                           customsDataStoreConnector: CustomsDataStoreConnector)
                                           (implicit mcc: MessagesControllerComponents,
                                            ec: ExecutionContext,
                                            appConfig: AppConfig) extends FrontendController(mcc) with I18nSupport {
@@ -51,9 +51,15 @@ class ConfirmationPageController @Inject()(override val messagesApi: MessagesApi
     implicit request =>
 
       val result: Future[Result] = for {
-        dates: Option[CashTransactionDates] <- cache.get(request.eori)
+        dates <- cache.get(request.eori)
+        email <- customsDataStoreConnector.getEmail(request.eori)
       } yield {
-        checkDatesAndRedirect(dates)
+        email match {
+          case Right(email) =>
+            checkDatesAndRedirect(dates, email.value)
+          case Left(_) =>
+            checkDatesAndRedirect(dates, emptyString)
+        }
       }
 
       result.recover {
@@ -63,16 +69,16 @@ class ConfirmationPageController @Inject()(override val messagesApi: MessagesApi
       }
   }
 
-  private def checkDatesAndRedirect(optionalDates: Option[CashTransactionDates])
-                                  (implicit request: IdentifierRequest[AnyContent],
-                                   messages: Messages): Result = {
+  private def checkDatesAndRedirect(optionalDates: Option[CashTransactionDates], email: String)
+                                   (implicit request: IdentifierRequest[AnyContent],
+                                    messages: Messages): Result = {
     optionalDates match {
       case Some(dates) =>
 
         val startDate = dateAsMonthAndYear(dates.start)
         val endDate = dateAsMonthAndYear(dates.end)
 
-        Ok(view(s"$startDate ${messages("month.to")} $endDate"))
+        Ok(view(s"$startDate ${messages("month.to")} $endDate", email))
 
       case _ =>
         log.error(s"filed to load checkDatesAndRedirect $optionalDates")

--- a/app/controllers/ConfirmationPageController.scala
+++ b/app/controllers/ConfirmationPageController.scala
@@ -56,9 +56,9 @@ class ConfirmationPageController @Inject()(override val messagesApi: MessagesApi
       } yield {
         email match {
           case Right(email) =>
-            checkDatesAndRedirect(dates, email.value)
+            checkDatesAndEmailAndRedirect(dates, email.value)
           case Left(_) =>
-            checkDatesAndRedirect(dates, emptyString)
+            checkDatesAndEmailAndRedirect(dates, emptyString)
         }
       }
 
@@ -69,9 +69,9 @@ class ConfirmationPageController @Inject()(override val messagesApi: MessagesApi
       }
   }
 
-  private def checkDatesAndRedirect(optionalDates: Option[CashTransactionDates], email: String)
-                                   (implicit request: IdentifierRequest[AnyContent],
-                                    messages: Messages): Result = {
+  private def checkDatesAndEmailAndRedirect(optionalDates: Option[CashTransactionDates], email: String)
+                                           (implicit request: IdentifierRequest[AnyContent],
+                                            messages: Messages): Result = {
     optionalDates match {
       case Some(dates) =>
 

--- a/app/views/confirmation_page.scala.html
+++ b/app/views/confirmation_page.scala.html
@@ -16,57 +16,56 @@
 
 @import config.AppConfig
 @import views.html.Layout
-@import uk.gov.hmrc.auth.core.retrieve.Email
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukPanel
 
 @this(
-        layout: Layout,
-        link: components.link,
-        p: components.p,
-        h1: components.h1,
-        h2: components.h2,
-        govukPanel: GovukPanel
+  layout: Layout,
+  link: components.link,
+  p: components.p,
+  h2: components.h2,
+  govukPanel: GovukPanel
 )
 
 @(
-    dates: String
+  dates: String,
+  email: String
 )(
-    implicit request: Request[_],
-    messages: Messages,
-    appConfig: AppConfig
+  implicit request: Request[_],
+  messages: Messages,
+  appConfig: AppConfig
 )
 
 @layout(
-    pageTitle = Some(messages("cf.cash-account.transactions.confirmation.statements")),
-    fullWidth = false,
-    help = false
+  pageTitle = Some(messages("cf.cash-account.transactions.confirmation.statements")),
+  fullWidth = false,
+  help = false
 ) {
 
-    @govukPanel(Panel(
-        title = Text(messages("cf.cash-account.transactions.confirmation.statements")),
-        headingLevel = 1,
-        content = Text(dates)
-    ))
+  @govukPanel(Panel(
+    title = Text(messages("cf.cash-account.transactions.confirmation.statements")),
+    headingLevel = 1,
+    content = Text(dates)
+  ))
 
-    @h2(
-        msg = messages(s"cf.cash-account.transactions.confirmation.next"),
-        classes = "govuk-heading-s",
-        id=Some("email-confirmation-subheader")
-    )
+  @h2(
+    msg = messages(s"cf.cash-account.transactions.confirmation.next"),
+    classes = "govuk-heading-s",
+    id=Some("email-confirmation-subheader")
+  )
 
-    @p(
-        message = s"${messages("cf.cash-account.transactions.confirmation.email")}",
-        id=Some("body-text-email")
-    )
+  @p(
+    message = messages("cf.cash-account.transactions.confirmation.email", email),
+    id=Some("body-text-email")
+  )
 
-    @p(
-        message = s"${messages("cf.cash-account.transactions.confirmation.download")}",
-        id=Some("body-text-download")
-    )
+  @p(
+    message = s"${messages("cf.cash-account.transactions.confirmation.download")}",
+    id=Some("body-text-download")
+  )
 
-    @link(
-        linkMessage = Some(messages(s"cf.cash-account.transactions.confirmation.back")),
-        location = controllers.routes.CashAccountController.showAccountDetails(None).url,
-        pId = Some("link-text"),
-        pClass = "govuk-body govuk-!-margin-bottom-9")
+  @link(
+    linkMessage = Some(messages(s"cf.cash-account.transactions.confirmation.back")),
+    location = controllers.routes.CashAccountController.showAccountDetails(None).url,
+    pId = Some("link-text"),
+    pClass = "govuk-body govuk-!-margin-bottom-9")
 }

--- a/app/views/confirmation_page.scala.html
+++ b/app/views/confirmation_page.scala.html
@@ -28,7 +28,7 @@
 
 @(
   dates: String,
-  email: String
+  email: Option[String]
 )(
   implicit request: Request[_],
   messages: Messages,
@@ -53,10 +53,12 @@
     id=Some("email-confirmation-subheader")
   )
 
-  @p(
-    message = messages("cf.cash-account.transactions.confirmation.email", email),
-    id=Some("body-text-email")
-  )
+  @email.filter(_.nonEmpty).map { emailAddress =>
+    @p(
+      message = messages("cf.cash-account.transactions.confirmation.email", emailAddress),
+      id = Some("body-text-email")
+    )
+  }
 
   @p(
     message = s"${messages("cf.cash-account.transactions.confirmation.download")}",

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -300,7 +300,7 @@ cf.cash-account.transactions.request.date.hint-end-date.v2=Er enghraifft, 3 2021
 
 cf.cash-account.transactions.confirmation.statements=Mae’ch cais am drafodion wedi dod i law
 cf.cash-account.transactions.confirmation.next=Yr hyn sy’n digwydd nesaf
-cf.cash-account.transactions.confirmation.email=Byddwn yn anfon e-bost at someemail@mail.com cyn pen 48 awr pan fydd eich cais wedi’i brosesu.
+cf.cash-account.transactions.confirmation.email=Byddwn yn anfon e-bost at {0} cyn pen 48 awr pan fydd eich cais wedi’i brosesu.
 cf.cash-account.transactions.confirmation.download=Byddwch yn gallu lawrlwytho’ch trafodion o’r dudalen trafodion cyfrifon arian parod.
 cf.cash-account.transactions.confirmation.back=Yn ôl i ‘cyfrif arian parod’
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -300,7 +300,7 @@ cf.cash-account.transactions.too-many-transactions.hint04 = The CSV file will be
 
 cf.cash-account.transactions.confirmation.statements=We received your request for transactions
 cf.cash-account.transactions.confirmation.next=What happens next
-cf.cash-account.transactions.confirmation.email=We’ll send an email within 48 hours to someemail@mail.com when your request is processed.
+cf.cash-account.transactions.confirmation.email=We’ll send an email within 48 hours to {0} when your request is processed.
 cf.cash-account.transactions.confirmation.download=You’ll be able to download your transactions from the cash account transactions page.
 cf.cash-account.transactions.confirmation.back=Back to cash account
 

--- a/test/controllers/ConfirmationPageControllerSpec.scala
+++ b/test/controllers/ConfirmationPageControllerSpec.scala
@@ -54,7 +54,7 @@ class ConfirmationPageControllerSpec extends SpecBase {
 
   "calling page load returns valid response without email address" in new Setup {
     when(mockRequestedTransactionsCache.get(any)).thenReturn(Future.successful(Some(cashDates)))
-    when(mockCustomsDataStoreConnector.getEmail(any)(any)).thenReturn(Future.successful(Left(Email(emptyString))))
+    when(mockCustomsDataStoreConnector.getEmail(any)(any)).thenReturn(Future.successful(Right(Email(emptyString))))
 
     val request: FakeRequest[AnyContentAsEmpty.type] =
       fakeRequest(GET, routes.ConfirmationPageController.onPageLoad().url)

--- a/test/controllers/ConfirmationPageControllerSpec.scala
+++ b/test/controllers/ConfirmationPageControllerSpec.scala
@@ -49,7 +49,7 @@ class ConfirmationPageControllerSpec extends SpecBase {
 
   "calling pageload returns error and redirects to cash account" in new Setup {
     when(mockRequestedTransactionsCache.get(any)).thenReturn(Future.successful(Some(emptyString)))
-    when(mockCustomsDataStoreConnector.getEmail(any)(any)).thenReturn(Future.successful(Right(Email(email))))
+    when(mockCustomsDataStoreConnector.getEmail(any)(any)).thenReturn(Future.successful(Right(Email(emptyString))))
 
     val request: FakeRequest[AnyContentAsEmpty.type] =
       fakeRequest(GET, routes.ConfirmationPageController.onPageLoad().url)

--- a/test/controllers/ConfirmationPageControllerSpec.scala
+++ b/test/controllers/ConfirmationPageControllerSpec.scala
@@ -86,7 +86,7 @@ class ConfirmationPageControllerSpec extends SpecBase {
 
   "calling page load returns error and redirects to cash account" in new Setup {
     when(mockRequestedTransactionsCache.get(any)).thenReturn(Future.successful(Some(emptyString)))
-    when(mockCustomsDataStoreConnector.getEmail(any)(any)).thenReturn(Future.successful(Right(Email(emptyString))))
+    when(mockCustomsDataStoreConnector.getEmail(any)(any)).thenReturn(Future.successful(Left(Email(emptyString))))
 
     val request: FakeRequest[AnyContentAsEmpty.type] =
       fakeRequest(GET, routes.ConfirmationPageController.onPageLoad().url)

--- a/test/controllers/DeclarationDetailControllerSpec.scala
+++ b/test/controllers/DeclarationDetailControllerSpec.scala
@@ -52,7 +52,6 @@ import play.api.inject.bind
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
-import play.twirl.api.Html
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.SpecBase
 

--- a/test/controllers/SelectedTransactionsControllerSpec.scala
+++ b/test/controllers/SelectedTransactionsControllerSpec.scala
@@ -282,7 +282,6 @@ class SelectedTransactionsControllerSpec extends SpecBase {
     val sMRN: Option[String] = Some("ic62zbad-75fa-445f-962b-cc92311686b8e")
     val cashAccountNumber = "1234567"
     val eori = "exampleEori"
-    val someCan = "1234567"
     val mockCustomsFinancialsApiConnector: CustomsFinancialsApiConnector = mock[CustomsFinancialsApiConnector]
     val mockRequestedTransactionsCache: RequestedTransactionsCache = mock[RequestedTransactionsCache]
 

--- a/test/views/ConfirmationPageSpec.scala
+++ b/test/views/ConfirmationPageSpec.scala
@@ -49,9 +49,13 @@ class ConfirmationPageSpec extends SpecBase with ViewTestHelper {
           "cf.cash-account.transactions.confirmation.next")
       }
 
-      "body text email is correct" in new Setup {
+      "body text email is correct and email address is present" in new Setup {
         view.getElementById("body-text-email").text() mustBe messages(
           "cf.cash-account.transactions.confirmation.email", email)
+      }
+
+      "email address is not present" in new Setup {
+        Option(viewWithoutEmail.getElementById("body-text-email")) mustBe None
       }
 
       "body text download is correct" in new Setup {
@@ -72,6 +76,7 @@ class ConfirmationPageSpec extends SpecBase with ViewTestHelper {
     val dates = s"$startDate ${messages("month.to")} $endDate"
     val email = "jackiechan@mail.com"
 
-    val view: Document = Jsoup.parse(app.injector.instanceOf[confirmation_page].apply(dates, email).body)
+    val view: Document = Jsoup.parse(app.injector.instanceOf[confirmation_page].apply(dates, Some(email)).body)
+    val viewWithoutEmail: Document = Jsoup.parse(app.injector.instanceOf[confirmation_page].apply(dates, None).body)
   }
 }

--- a/test/views/ConfirmationPageSpec.scala
+++ b/test/views/ConfirmationPageSpec.scala
@@ -50,13 +50,13 @@ class ConfirmationPageSpec extends SpecBase with ViewTestHelper {
       }
 
       "body text email is correct" in new Setup {
-        view.getElementById("body-text-email").text() mustBe s"${messages(
-          "cf.cash-account.transactions.confirmation.email")}"
+        view.getElementById("body-text-email").text() mustBe messages(
+          "cf.cash-account.transactions.confirmation.email", email)
       }
 
       "body text download is correct" in new Setup {
-        view.getElementById("body-text-download").text() mustBe s"${messages(
-          "cf.cash-account.transactions.confirmation.download")}"
+        view.getElementById("body-text-download").text() mustBe messages(
+          "cf.cash-account.transactions.confirmation.download")
       }
 
       "link text is correct" in new Setup {
@@ -70,7 +70,8 @@ class ConfirmationPageSpec extends SpecBase with ViewTestHelper {
     val startDate = "March 2022"
     val endDate = "April 2022"
     val dates = s"$startDate ${messages("month.to")} $endDate"
+    val email = "jackiechan@mail.com"
 
-    val view: Document = Jsoup.parse(app.injector.instanceOf[confirmation_page].apply(dates).body)
+    val view: Document = Jsoup.parse(app.injector.instanceOf[confirmation_page].apply(dates, email).body)
   }
 }


### PR DESCRIPTION
**Context:**
Retrieve registered email address from the customs-data-store and display it on the cash account transaction request confirmation page (instead of the hardcoded email address value)

**Dev tasks:**
- [x] Retrieve email address from data store to display on cash account transaction request confirmation page  
- [x] Use '/eori/:eori/verified-email' endpoint from customs-data-store to retrieve the verified email address
- [x] Display it on confirmation page
- [x] Add or amend unit tests