### PR TITLE
[MMCA-5005] - Update test structure to use a common instance of application builder and app config

### DIFF
--- a/test/behaviours/GuidancePageBehaviour.scala
+++ b/test/behaviours/GuidancePageBehaviour.scala
@@ -35,7 +35,7 @@ trait GuidancePageBehaviour {
   val otherComponentGuidanceList: List[ComponentDetailsForAssertion] = List.empty
   val linksToVerify: List[LinkDetails] = List.empty
 
-  implicit lazy val app: Application = buildApp
+  implicit lazy val app: Application = application
   implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest()
 
   def guidancePage(): Unit =

--- a/test/behaviours/GuidancePageBehaviour.scala
+++ b/test/behaviours/GuidancePageBehaviour.scala
@@ -38,13 +38,12 @@ trait GuidancePageBehaviour {
   val linksToVerify: List[LinkDetails] = List.empty
 
   implicit lazy val app: Application = buildApp
-  implicit val msgs: Messages = messages(app)
   implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest()
 
   def guidancePage(): Unit =
 
     "display correct title" in {
-      view.title() mustBe s"${msgs(titleMsgKey)} - ${msgs("service.name")} - GOV.UK"
+      view.title() mustBe s"${messages(titleMsgKey)} - ${messages("service.name")} - GOV.UK"
     }
 
     "display correct back link" in {
@@ -53,13 +52,13 @@ trait GuidancePageBehaviour {
 
     "display correct help and support guidance" in {
       if (helpAndSupportMsgKeys.isDefined) {
-        helpAndSupportMsgKeys.map(msgsKey => view.html().contains(msgs(msgsKey)) mustBe true)
+        helpAndSupportMsgKeys.map(msgsKey => view.html().contains(messages(msgsKey)) mustBe true)
       } else {
         val viewAsHtml = view.html()
 
-        viewAsHtml must include(msgs("cf.cash-account.help-and-support.link.text"))
-        viewAsHtml must include(msgs("cf.cash-account.help-and-support.link.text.post"))
-        viewAsHtml must include(msgs("cf.cash-account.help-and-support.link.text.pre"))
+        viewAsHtml must include(messages("cf.cash-account.help-and-support.link.text"))
+        viewAsHtml must include(messages("cf.cash-account.help-and-support.link.text.post"))
+        viewAsHtml must include(messages("cf.cash-account.help-and-support.link.text.pre"))
         viewAsHtml must include(
           helpAndSupportLink.getOrElse("https://www.gov.uk/guidance/use-a-cash-account-for-cds-declarations"))
       }

--- a/test/behaviours/GuidancePageBehaviour.scala
+++ b/test/behaviours/GuidancePageBehaviour.scala
@@ -37,10 +37,9 @@ trait GuidancePageBehaviour {
   val otherComponentGuidanceList: List[ComponentDetailsForAssertion] = List.empty
   val linksToVerify: List[LinkDetails] = List.empty
 
-  implicit lazy val app: Application = application.build()
+  implicit lazy val app: Application = buildApp
   implicit val msgs: Messages = messages(app)
   implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest()
-  implicit val appConfig: AppConfig = appConfig(app)
 
   def guidancePage(): Unit =
 

--- a/test/behaviours/GuidancePageBehaviour.scala
+++ b/test/behaviours/GuidancePageBehaviour.scala
@@ -16,10 +16,8 @@
 
 package behaviours
 
-import config.AppConfig
 import org.jsoup.nodes.Document
 import play.api.Application
-import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import utils.SpecBase

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -17,7 +17,6 @@
 package config
 
 import models.FileRole.CDSCashAccount
-import play.api.Application
 import utils.SpecBase
 
 class AppConfigSpec extends SpecBase {

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -24,7 +24,7 @@ class AppConfigSpec extends SpecBase {
 
   "AppConfig" should {
 
-    "contain correct values for the provided configuration" in new Setup {
+    "contain correct values for the provided configuration" in {
       appConfig.appName mustBe "customs-cash-account-frontend"
       appConfig.loginUrl mustBe "http://localhost:9553/bas-gateway/sign-in"
       appConfig.loginContinueUrl mustBe "http://localhost:9394/customs/cash-account"
@@ -63,7 +63,7 @@ class AppConfigSpec extends SpecBase {
   }
 
   "isCashAccountV2FeatureFlagEnabled" should {
-    "return the correct value" in new Setup {
+    "return the correct value" in {
       assume(!appConfig.isCashAccountV2FeatureFlagEnabled)
 
       appConfig.isCashAccountV2FeatureFlagEnabled mustBe false
@@ -71,20 +71,15 @@ class AppConfigSpec extends SpecBase {
   }
 
   "numberOfRecordsPerPage" should {
-    "return the correct value" in new Setup {
+    "return the correct value" in {
       appConfig.numberOfRecordsPerPage mustBe 30
     }
   }
 
   "numberOfRecordsToDisableNavigationButtonsInPagination" should {
-    "return the correct value" in new Setup {
+    "return the correct value" in {
       appConfig.numberOfRecordsToDisableNavigationButtonsInPagination mustBe 450
     }
   }
 
-
-  trait Setup {
-    val app: Application = application.build()
-    val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
-  }
 }

--- a/test/connectors/CustomsFinancialsApiConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsApiConnectorSpec.scala
@@ -66,7 +66,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       when[Future[Seq[CashAccount]]](mockMetricsReporterService.withResponseTimeLogging(any)(any)(any))
         .thenReturn(Future.successful(Seq(cashAccount)))
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient),
           bind[MetricsReporterService].toInstance(mockMetricsReporterService)
@@ -97,7 +97,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
         .thenReturn(Future.successful(successResponse))
       when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient),
           bind[CacheRepository].toInstance(mockCacheRepository),
@@ -142,7 +142,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
       when(mockCacheRepository.get("can")).thenReturn(Future.successful(None))
       when(mockCacheRepository.set("can", successResponse)).thenReturn(Future.successful(false))
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient),
           bind[MetricsReporterService].toInstance(mockMetricsReporterService),
@@ -165,7 +165,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
       when(mockCacheRepository.get(anyString)).thenReturn(Future.successful(Some(successResponse)))
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[AppConfig].toInstance(mockConfig),
           bind[CacheRepository].toInstance(mockCacheRepository)
@@ -185,7 +185,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
       when(mockCacheRepository.get("can")).thenReturn(Future.successful(None))
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient),
           bind[CacheRepository].toInstance(mockCacheRepository)
@@ -205,7 +205,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
         .thenReturn(Future.failed(UpstreamErrorResponse("Error occurred", REQUEST_ENTITY_TOO_LARGE)))
       when(mockHttpClient.post(any())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient),
           bind[CacheRepository].toInstance(mockCacheRepository)
@@ -226,7 +226,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
         .thenReturn(Future.failed(UpstreamErrorResponse("Error occurred", NOT_FOUND)))
       when(mockHttpClient.post(any())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient),
           bind[CacheRepository].toInstance(mockCacheRepository)
@@ -258,7 +258,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
         when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-        val appWithMocks: Application = application
+        val appWithMocks: Application = applicationBuilder
           .overrides(
             bind[HttpClientV2].toInstance(mockHttpClient),
             bind[RequestBuilder].toInstance(requestBuilder),
@@ -288,7 +288,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
         when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-        val appWithMocks: Application = application
+        val appWithMocks: Application = applicationBuilder
           .overrides(
             bind[HttpClientV2].toInstance(mockHttpClient),
             bind[RequestBuilder].toInstance(requestBuilder),
@@ -316,7 +316,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
       when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient)
         ).build()
@@ -337,7 +337,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
       when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient)
         ).build()
@@ -358,7 +358,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
       when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient)
         ).build()
@@ -379,7 +379,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
       when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient)
         ).build()
@@ -404,7 +404,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
         when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-        val appWithMocks: Application = application
+        val appWithMocks: Application = applicationBuilder
           .overrides(
             bind[HttpClientV2].toInstance(mockHttpClient)
           ).build()
@@ -427,7 +427,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
         when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-        val appWithMocks: Application = application
+        val appWithMocks: Application = applicationBuilder
           .overrides(
             bind[HttpClientV2].toInstance(mockHttpClient)
           ).build()
@@ -450,7 +450,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
         when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-        val appWithMocks: Application = application
+        val appWithMocks: Application = applicationBuilder
           .overrides(
             bind[HttpClientV2].toInstance(mockHttpClient)
           ).build()
@@ -473,7 +473,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
         when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-        val appWithMocks: Application = application
+        val appWithMocks: Application = applicationBuilder
           .overrides(
             bind[HttpClientV2].toInstance(mockHttpClient)
           ).build()
@@ -496,7 +496,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
         when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-        val appWithMocks: Application = application
+        val appWithMocks: Application = applicationBuilder
           .overrides(
             bind[HttpClientV2].toInstance(mockHttpClient)
           ).build()
@@ -519,7 +519,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
         when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-        val appWithMocks: Application = application
+        val appWithMocks: Application = applicationBuilder
           .overrides(
             bind[HttpClientV2].toInstance(mockHttpClient)
           ).build()
@@ -543,7 +543,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
         when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-        val appWithMocks: Application = application
+        val appWithMocks: Application = applicationBuilder
           .overrides(
             bind[HttpClientV2].toInstance(mockHttpClient)
           ).build()
@@ -567,7 +567,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
         when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-        val appWithMocks: Application = application
+        val appWithMocks: Application = applicationBuilder
           .overrides(
             bind[HttpClientV2].toInstance(mockHttpClient)
           ).build()
@@ -593,7 +593,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
         .thenReturn(Future.successful(successResponse))
       when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient),
           bind[RequestBuilder].toInstance(requestBuilder)
@@ -611,7 +611,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
         .thenReturn(Future.failed(new HttpException("It's broken", INTERNAL_SERVER_ERROR)))
       when(mockHttpClient.post(any())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient)
         ).build()
@@ -629,7 +629,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
         .thenReturn(Future.failed(UpstreamErrorResponse("Error occurred", REQUEST_ENTITY_TOO_LARGE)))
       when(mockHttpClient.post(any())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient)
         ).build()
@@ -647,7 +647,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
         .thenReturn(Future.failed(UpstreamErrorResponse("Error occurred", NOT_FOUND)))
       when(mockHttpClient.post(any())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient)
         ).build()
@@ -668,7 +668,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
       when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient),
           bind[RequestBuilder].toInstance(requestBuilder)
@@ -689,7 +689,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
       when(mockHttpClient.post(any())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(bind[HttpClientV2].toInstance(mockHttpClient)).build()
 
       running(appWithMocks) {
@@ -710,7 +710,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
       when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient),
           bind[RequestBuilder].toInstance(requestBuilder)
@@ -730,7 +730,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
       when(mockHttpClient.post(any())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient)
         ).build()
@@ -749,7 +749,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
       when(mockHttpClient.post(any())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient)
         ).build()
@@ -768,7 +768,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
       when(mockHttpClient.post(any())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient)
         ).build()
@@ -791,7 +791,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
       when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
-      val appWithMocks: Application = application
+      val appWithMocks: Application = applicationBuilder
         .overrides(
           bind[HttpClientV2].toInstance(mockHttpClient),
           bind[RequestBuilder].toInstance(requestBuilder)
@@ -935,7 +935,7 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
     val errorDetailObject: ErrorDetail =
       ErrorDetail(timestamp, correlationId, errorCode, errorMessage, source, sourceFaultDetail)
 
-    val appWithHttpClient: Application = application
+    val appWithHttpClient: Application = applicationBuilder
       .overrides(
         bind[HttpClientV2].toInstance(mockHttpClient),
         bind[RequestBuilder].toInstance(requestBuilder)

--- a/test/connectors/DataStoreConnectorSpec.scala
+++ b/test/connectors/DataStoreConnectorSpec.scala
@@ -182,7 +182,7 @@ class DataStoreConnectorSpec extends SpecBase {
     val requestBuilder: RequestBuilder = mock[RequestBuilder]
     val mockMetricsReporter: MetricsReporterService = mock[MetricsReporterService]
 
-    val app: Application = application.overrides(
+    val app: Application = applicationBuilder.overrides(
       bind[HttpClientV2].toInstance(mockHttpClient),
       bind[RequestBuilder].toInstance(requestBuilder),
       bind[MetricsReporterService].toInstance(mockMetricsReporter)

--- a/test/connectors/SdesConnectorSpec.scala
+++ b/test/connectors/SdesConnectorSpec.scala
@@ -62,7 +62,7 @@ class SdesConnectorSpec extends SpecBase {
     val mockHttp: HttpClientV2 = mock[HttpClientV2]
     val requestBuilder: RequestBuilder = mock[RequestBuilder]
 
-    val app: Application = application.overrides(
+    val app: Application = applicationBuilder.overrides(
       bind[HttpClientV2].toInstance(mockHttp),
       bind[RequestBuilder].toInstance(requestBuilder)
     ).build()

--- a/test/connectors/SdesConnectorSpec.scala
+++ b/test/connectors/SdesConnectorSpec.scala
@@ -16,16 +16,14 @@
 
 package connectors
 
-import config.AppConfig
 import models.*
 import models.FileFormat.Csv
 import models.FileRole.CDSCashAccount
 import models.metadata.{CashStatementFileMetadata, Metadata, MetadataItem}
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
-import play.api.i18n.{Messages, MessagesApi}
 import play.api.inject.bind
-import play.api.test.{FakeRequest, Helpers}
+import play.api.test.Helpers
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, StringContextOps}

--- a/test/connectors/SdesConnectorSpec.scala
+++ b/test/connectors/SdesConnectorSpec.scala
@@ -67,12 +67,10 @@ class SdesConnectorSpec extends SpecBase {
       bind[RequestBuilder].toInstance(requestBuilder)
     ).build()
 
-    val mockAppConfig: AppConfig = app.injector.instanceOf[AppConfig]
     val sdesConnector: SdesConnector = app.injector.instanceOf[SdesConnector]
 
     implicit val hc: HeaderCarrier = HeaderCarrier()
     implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
-    implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
 
     val someDan = "1234"
     val someEori = "eori1"

--- a/test/controllers/CashAccountControllerSpec.scala
+++ b/test/controllers/CashAccountControllerSpec.scala
@@ -494,7 +494,7 @@ class CashAccountControllerSpec extends SpecBase {
     val cashTransactionResponse: CashTransactions = CashTransactions(
       listOfPendingTransactions, cashDailyStatements)
 
-    val appConfigOb: AppConfig = buildApp.injector.instanceOf[AppConfig]
+    val appConfigOb: AppConfig = application.injector.instanceOf[AppConfig]
 
     assume(!appConfigOb.isCashAccountV2FeatureFlagEnabled)
   }

--- a/test/controllers/CashAccountControllerSpec.scala
+++ b/test/controllers/CashAccountControllerSpec.scala
@@ -51,7 +51,7 @@ class CashAccountControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -71,7 +71,7 @@ class CashAccountControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -90,7 +90,7 @@ class CashAccountControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Left(UnknownException)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -125,7 +125,7 @@ class CashAccountControllerSpec extends SpecBase {
         .thenReturn(Future.successful(Left(NoTransactionsAvailable)))
 
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -156,7 +156,7 @@ class CashAccountControllerSpec extends SpecBase {
         .thenReturn(Future.successful(Left(NoTransactionsAvailable)))
 
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -188,7 +188,7 @@ class CashAccountControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Left(NoTransactionsAvailable)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -219,7 +219,7 @@ class CashAccountControllerSpec extends SpecBase {
         .thenReturn(Future.successful(Right(CashTransactions(Seq.empty, Seq.empty))))
 
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -249,7 +249,7 @@ class CashAccountControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Left(TooManyTransactionsRequested)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -267,7 +267,7 @@ class CashAccountControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
         .thenReturn(Future.successful(None))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -286,7 +286,7 @@ class CashAccountControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -304,7 +304,7 @@ class CashAccountControllerSpec extends SpecBase {
           Future.failed(nonFatalResponse)
         )
 
-        val app: Application = application
+        val app: Application = applicationBuilder
           .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
           .build()
 
@@ -322,7 +322,7 @@ class CashAccountControllerSpec extends SpecBase {
       when(mockDataStoreConnector.getEmail(any)(any))
         .thenReturn(Future.successful(Left(UnverifiedEmail)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(
           bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
           bind[CustomsDataStoreConnector].toInstance(mockDataStoreConnector)
@@ -344,7 +344,7 @@ class CashAccountControllerSpec extends SpecBase {
 
       private val request = FakeRequest(GET, routes.CashAccountController.showAccountDetails(Some(1)).url)
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(
           bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
           bind[CustomsDataStoreConnector].toInstance(mockDataStoreConnector)
@@ -368,7 +368,7 @@ class CashAccountControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(
           bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
           bind[CustomsDataStoreConnector].toInstance(mockDataStoreConnector)
@@ -386,7 +386,7 @@ class CashAccountControllerSpec extends SpecBase {
 
   "showAccountUnavailable" must {
     "return OK" in new Setup {
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -402,7 +402,7 @@ class CashAccountControllerSpec extends SpecBase {
   "showUnableToDownloadCSV" must {
 
     "return OK" in new Setup {
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -418,7 +418,7 @@ class CashAccountControllerSpec extends SpecBase {
   "tooManyTransactions" must {
     "return OK" in new Setup {
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -435,7 +435,7 @@ class CashAccountControllerSpec extends SpecBase {
 
     "return NotFound" in new Setup {
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -494,7 +494,7 @@ class CashAccountControllerSpec extends SpecBase {
     val cashTransactionResponse: CashTransactions = CashTransactions(
       listOfPendingTransactions, cashDailyStatements)
 
-    val appConfigOb: AppConfig = application.build().injector.instanceOf[AppConfig]
+    val appConfigOb: AppConfig = buildApp.injector.instanceOf[AppConfig]
 
     assume(!appConfigOb.isCashAccountV2FeatureFlagEnabled)
   }

--- a/test/controllers/CashAccountPaymentSearchControllerSpec.scala
+++ b/test/controllers/CashAccountPaymentSearchControllerSpec.scala
@@ -127,9 +127,7 @@ class CashAccountPaymentSearchControllerSpec extends SpecBase {
         bind[CashAccountSearchRepository].toInstance(mockCashAccountSearchRepo)
       ).build()
 
-    implicit val msgs: Messages = messages(app)
-
-    val noResultsReturnedMessage: String = msgs(
+    val noResultsReturnedMessage: String = messages(
       "cf.cash-account.detail.declaration.search-no-results-guidance-not-returned-any-results", PAYMENT_SEARCH_VALUE)
   }
 }

--- a/test/controllers/CashAccountPaymentSearchControllerSpec.scala
+++ b/test/controllers/CashAccountPaymentSearchControllerSpec.scala
@@ -16,7 +16,6 @@
 
 package controllers
 
-import config.AppConfig
 import connectors.*
 import models.response.*
 import models.*
@@ -24,7 +23,6 @@ import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito
 import org.mockito.Mockito.when
 import play.api.Application
-import play.api.i18n.Messages
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*

--- a/test/controllers/CashAccountPaymentSearchControllerSpec.scala
+++ b/test/controllers/CashAccountPaymentSearchControllerSpec.scala
@@ -121,14 +121,13 @@ class CashAccountPaymentSearchControllerSpec extends SpecBase {
       AccountStatusOpen,
       CDSCashBalance(Some(BigDecimal(123456.78))))
 
-    val app: Application = application
+    val app: Application = applicationBuilder
       .overrides(
         bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
         bind[CashAccountSearchRepository].toInstance(mockCashAccountSearchRepo)
       ).build()
 
     implicit val msgs: Messages = messages(app)
-    implicit val config: AppConfig = appConfig(app)
 
     val noResultsReturnedMessage: String = msgs(
       "cf.cash-account.detail.declaration.search-no-results-guidance-not-returned-any-results", PAYMENT_SEARCH_VALUE)

--- a/test/controllers/CashAccountV2ControllerSpec.scala
+++ b/test/controllers/CashAccountV2ControllerSpec.scala
@@ -249,8 +249,6 @@ class CashAccountV2ControllerSpec extends SpecBase {
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
-      implicit val msgs: Messages = messages(app)
-
       running(app) {
         implicit val request: FakeRequest[AnyContentAsEmpty.type] =
           FakeRequest(GET, routes.CashAccountV2Controller.showAccountDetails(Some(1)).url)
@@ -260,7 +258,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
         status(result) mustEqual OK
 
         contentAsString(result) must
-          include regex msgs("cf.cash-account.transactions.no-transactions-for-last-six-months")
+          include regex messages("cf.cash-account.transactions.no-transactions-for-last-six-months")
       }
     }
 
@@ -270,8 +268,6 @@ class CashAccountV2ControllerSpec extends SpecBase {
         .overrides(
           bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector)
         ).build()
-
-      implicit val msgs: Messages = messages(app)
 
       val cashAccountWithZeroBalance: CashAccount = cashAccount.copy(balances = CDSCashBalance(Some(0)))
 
@@ -581,7 +577,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
         val result = route(app, request).value
         status(result) mustEqual SEE_OTHER
 
-        val renderedView = view.apply(formWithErrors, viewModel)(messages(app), appConfig, request).body
+        val renderedView = view.apply(formWithErrors, viewModel)(messages, appConfig, request).body
         renderedView must include("There is a problem")
         renderedView must include(s"Enter an MRN, UCR or exact payment amount that includes &#x27;$poundSymbol&#x27;")
       }

--- a/test/controllers/CashAccountV2ControllerSpec.scala
+++ b/test/controllers/CashAccountV2ControllerSpec.scala
@@ -75,7 +75,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -95,7 +95,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -114,7 +114,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Left(UnknownException)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -148,7 +148,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Left(NoTransactionsAvailable)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -178,7 +178,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Left(NoTransactionsAvailable)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -210,7 +210,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Left(NoTransactionsAvailable)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -245,7 +245,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(any, any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionsWithNoStatements)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -266,13 +266,12 @@ class CashAccountV2ControllerSpec extends SpecBase {
 
     "display cash account no transactions' page when user does not have Cash account and balance is zero" in new Setup {
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(
           bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector)
         ).build()
 
       implicit val msgs: Messages = messages(app)
-      implicit val config: AppConfig = appConfig(app)
 
       val cashAccountWithZeroBalance: CashAccount = cashAccount.copy(balances = CDSCashBalance(Some(0)))
 
@@ -306,7 +305,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Left(TooManyTransactionsRequested)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -327,7 +326,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse02)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -344,7 +343,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
         .thenReturn(Future.successful(None))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -364,7 +363,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -382,7 +381,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
           Future.failed(nonFatalResponse)
         )
 
-        val app: Application = application
+        val app: Application = applicationBuilder
           .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
           .build()
 
@@ -400,7 +399,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
       when(mockDataStoreConnector.getEmail(any)(any))
         .thenReturn(Future.successful(Left(UnverifiedEmail)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(
           bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
           bind[CustomsDataStoreConnector].toInstance(mockDataStoreConnector)
@@ -422,7 +421,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
 
       private val request = FakeRequest(GET, routes.CashAccountV2Controller.showAccountDetails(Some(1)).url)
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(
           bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
           bind[CustomsDataStoreConnector].toInstance(mockDataStoreConnector)
@@ -446,7 +445,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactions(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(
           bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
           bind[CustomsDataStoreConnector].toInstance(mockDataStoreConnector)
@@ -464,7 +463,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
 
   "showAccountUnavailable" must {
     "return OK" in new Setup {
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -480,7 +479,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
   "showUnableToDownloadCSV" must {
 
     "return OK" in new Setup {
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -496,7 +495,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
   "tooManyTransactions" must {
     "return OK" in new Setup {
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -513,7 +512,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
 
     "return NotFound" in new Setup {
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -532,7 +531,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
   "onSubmit" must {
 
     "return SEE_OTHER when form submission is successful" in new Setup {
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[DeclarationDetailController].toInstance(mockDeclarationDetailController))
         .build()
 
@@ -552,7 +551,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
     }
 
     "return same page when form submission is unsuccessful with error validation present" in new Setup {
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector)).build()
 
       running(app) {
@@ -582,7 +581,7 @@ class CashAccountV2ControllerSpec extends SpecBase {
         val result = route(app, request).value
         status(result) mustEqual SEE_OTHER
 
-        val renderedView = view.apply(formWithErrors, viewModel)(messages(app), appConfig(app), request).body
+        val renderedView = view.apply(formWithErrors, viewModel)(messages(app), appConfig, request).body
         renderedView must include("There is a problem")
         renderedView must include(s"Enter an MRN, UCR or exact payment amount that includes &#x27;$poundSymbol&#x27;")
       }

--- a/test/controllers/ConfirmationPageControllerSpec.scala
+++ b/test/controllers/ConfirmationPageControllerSpec.scala
@@ -22,7 +22,6 @@ import models.email.UndeliverableEmail
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.Application
-import play.api.i18n.{Messages, MessagesApi}
 import play.api.inject.bind
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest

--- a/test/controllers/ConfirmationPageControllerSpec.scala
+++ b/test/controllers/ConfirmationPageControllerSpec.scala
@@ -111,7 +111,7 @@ class ConfirmationPageControllerSpec extends SpecBase {
 
     val cashDates: CashTransactionDates = CashTransactionDates(start = fromDate, end = toDate)
 
-    val app: Application = application
+    val app: Application = applicationBuilder
       .overrides(
         bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
         bind[RequestedTransactionsCache].toInstance(mockRequestedTransactionsCache),

--- a/test/controllers/ConfirmationPageControllerSpec.scala
+++ b/test/controllers/ConfirmationPageControllerSpec.scala
@@ -118,7 +118,5 @@ class ConfirmationPageControllerSpec extends SpecBase {
         bind[CustomsDataStoreConnector].toInstance(mockCustomsDataStoreConnector))
       .configure("features.fixed-systemdate-for-tests" -> "true")
       .build()
-
-    val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(fakeRequest(emptyString, emptyString))
   }
 }

--- a/test/controllers/DeclarationDetailControllerSpec.scala
+++ b/test/controllers/DeclarationDetailControllerSpec.scala
@@ -535,11 +535,10 @@ class DeclarationDetailControllerSpec extends SpecBase {
 
     val declarationWrapper: DeclarationWrapper = DeclarationWrapper(declarationSearch)
 
-    val app: Application = application
+    val app: Application = applicationBuilder
       .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
       .build()
 
     implicit val msgs: Messages = messages(app)
-    implicit val config: AppConfig = appConfig(app)
   }
 }

--- a/test/controllers/DeclarationDetailControllerSpec.scala
+++ b/test/controllers/DeclarationDetailControllerSpec.scala
@@ -538,7 +538,5 @@ class DeclarationDetailControllerSpec extends SpecBase {
     val app: Application = applicationBuilder
       .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
       .build()
-
-    implicit val msgs: Messages = messages(app)
   }
 }

--- a/test/controllers/DeclarationDetailControllerSpec.scala
+++ b/test/controllers/DeclarationDetailControllerSpec.scala
@@ -35,7 +35,6 @@ import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito
 import org.mockito.Mockito.when
 import play.api.Application
-import play.api.i18n.Messages
 import play.api.inject.bind
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -46,7 +45,6 @@ import utils.SpecBase
 import java.time.LocalDate
 import scala.concurrent.Future
 import views.html.cash_account_declaration_details_search_no_result
-import config.AppConfig
 import utils.TestData.{PAYMENT_SEARCH_VALUE, SEQ_PAYMENT_DETAILS_CONTAINER_01}
 
 class DeclarationDetailControllerSpec extends SpecBase {

--- a/test/controllers/DownloadCsvControllerSpec.scala
+++ b/test/controllers/DownloadCsvControllerSpec.scala
@@ -50,7 +50,7 @@ class DownloadCsvControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactionsDetail(eqTo(someCan), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -69,7 +69,7 @@ class DownloadCsvControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactionsDetail(eqTo(someCan), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -112,7 +112,7 @@ class DownloadCsvControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactionsDetail(eqTo(someCan), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -132,7 +132,7 @@ class DownloadCsvControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactionsDetail(eqTo(someCan), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -154,7 +154,7 @@ class DownloadCsvControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactionsDetail(eqTo(someCan), any, any)(any))
         .thenReturn(Future.successful(Left(UnknownException)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
 
@@ -172,7 +172,7 @@ class DownloadCsvControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactionsDetail(eqTo(someCan), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(
           bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector)
         ).configure("features.fixed-systemdate-for-tests" -> "true"
@@ -197,7 +197,7 @@ class DownloadCsvControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactionsDetail(eqTo(someCan), any, any)(any))
         .thenReturn(Future.successful(Right(cashTransactionResponse)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(
           bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
           bind[AuditingService].toInstance(mockAuditingService)
@@ -222,7 +222,7 @@ class DownloadCsvControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
         .thenReturn(Future.successful(None))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(
           bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector)
         ).configure("features.fixed-systemdate-for-tests" -> "true"
@@ -237,7 +237,7 @@ class DownloadCsvControllerSpec extends SpecBase {
 
     "paginator" should {
       "be compatible with the page and mrn query parameter" in new Setup {
-        val app: Application = application
+        val app: Application = applicationBuilder
           .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
           .configure("application.cash-account.numberOfDaysToShow" -> "10")
           .build()
@@ -279,7 +279,7 @@ class DownloadCsvControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.retrieveCashTransactionsDetail(eqTo(cashAccountNumber), any, any)(any))
         .thenReturn(Future.successful(Left(TooManyTransactionsRequested)))
 
-      val app: Application = application
+      val app: Application = applicationBuilder
         .overrides(bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector))
         .build()
       running(app) {
@@ -445,7 +445,7 @@ class DownloadCsvControllerSpec extends SpecBase {
 
     val cashTransactionResponse: CashTransactions = CashTransactions(listOfPendingTransactions, cashDailyStatements)
 
-    val newApp: Application = application
+    val newApp: Application = applicationBuilder
       .overrides(
         bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
         bind[AuditingService].toInstance(mockAuditingService)

--- a/test/controllers/EmailControllerSpec.scala
+++ b/test/controllers/EmailControllerSpec.scala
@@ -98,7 +98,7 @@ class EmailControllerSpec extends SpecBase {
     val emailUnverifiedResponse: EmailUnverifiedResponse = EmailUnverifiedResponse(Some(emailId))
     val emailUnverifiedResponseWithNoEmailId: EmailUnverifiedResponse = EmailUnverifiedResponse(None)
 
-    val app: Application = application
+    val app: Application = applicationBuilder
       .overrides(
         bind[CustomsDataStoreConnector].toInstance(mockConnector)
       ).build()

--- a/test/controllers/LogoutControllerSpec.scala
+++ b/test/controllers/LogoutControllerSpec.scala
@@ -51,7 +51,7 @@ class LogoutControllerSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application
+    val app: Application = applicationBuilder
       .configure("feedback.url" -> "/some-continue", "feedback.source" -> "/CDS-FIN")
       .build()
   }

--- a/test/controllers/RequestTransactionsControllerSpec.scala
+++ b/test/controllers/RequestTransactionsControllerSpec.scala
@@ -199,7 +199,7 @@ RequestTransactionsControllerSpec extends SpecBase {
     val mockCustomsFinancialsApiConnector: CustomsFinancialsApiConnector = mock[CustomsFinancialsApiConnector]
     val mockRequestedTransactionsCache: RequestedTransactionsCache = mock[RequestedTransactionsCache]
 
-    val app: Application = application
+    val app: Application = applicationBuilder
       .overrides(
         bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
         bind[RequestedTransactionsCache].toInstance(mockRequestedTransactionsCache)

--- a/test/controllers/RequestTransactionsControllerSpec.scala
+++ b/test/controllers/RequestTransactionsControllerSpec.scala
@@ -204,8 +204,7 @@ RequestTransactionsControllerSpec extends SpecBase {
         bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
         bind[RequestedTransactionsCache].toInstance(mockRequestedTransactionsCache)
       )
-      .configure(
-        "features.fixed-systemdate-for-tests" -> "true")
+      .configure("features.fixed-systemdate-for-tests" -> "true")
       .build()
   }
 }

--- a/test/controllers/RequestedTransactionsControllerSpec.scala
+++ b/test/controllers/RequestedTransactionsControllerSpec.scala
@@ -215,7 +215,7 @@ class RequestedTransactionsControllerSpec extends SpecBase {
     val cashTransactionResponse: CashTransactions =
       CashTransactions(listOfPendingTransactions, cashDailyStatements)
 
-    val app: Application = application
+    val app: Application = applicationBuilder
       .overrides(
         bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
         bind[RequestedTransactionsCache].toInstance(mockRequestedTransactionsCache)

--- a/test/controllers/SelectTransactionsControllerSpec.scala
+++ b/test/controllers/SelectTransactionsControllerSpec.scala
@@ -202,8 +202,7 @@ class SelectTransactionsControllerSpec extends SpecBase {
         bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
         bind[RequestedTransactionsCache].toInstance(mockRequestedTransactionsCache)
       )
-      .configure(
-        "features.fixed-systemdate-for-tests" -> "true")
+      .configure("features.fixed-systemdate-for-tests" -> "true")
       .build()
   }
 }

--- a/test/controllers/SelectTransactionsControllerSpec.scala
+++ b/test/controllers/SelectTransactionsControllerSpec.scala
@@ -197,7 +197,7 @@ class SelectTransactionsControllerSpec extends SpecBase {
 
     val day: String = "1"
 
-    val app: Application = application
+    val app: Application = applicationBuilder
       .overrides(
         bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
         bind[RequestedTransactionsCache].toInstance(mockRequestedTransactionsCache)

--- a/test/controllers/SelectedTransactionsControllerSpec.scala
+++ b/test/controllers/SelectedTransactionsControllerSpec.scala
@@ -324,7 +324,7 @@ class SelectedTransactionsControllerSpec extends SpecBase {
     val accountResCommon02: AccountResponseCommon = AccountResponseCommon(
       "OK", Some("602-Exceeded maximum threshold of transactions"), "2021-12-17T09:30:47Z", None)
 
-    val app: Application = application
+    val app: Application = applicationBuilder
       .overrides(
         bind[CustomsFinancialsApiConnector].toInstance(mockCustomsFinancialsApiConnector),
         bind[RequestedTransactionsCache].toInstance(mockRequestedTransactionsCache)

--- a/test/controllers/UnauthorisedControllerSpec.scala
+++ b/test/controllers/UnauthorisedControllerSpec.scala
@@ -24,7 +24,7 @@ class UnauthorisedControllerSpec extends SpecBase {
   "onPageLoad" must {
 
     "return OK" in {
-      val app = application.build()
+      val app = buildApp
 
       running(app) {
         val result = route(app, fakeRequest("GET", routes.UnauthorisedController.onPageLoad.url)).value

--- a/test/controllers/UnauthorisedControllerSpec.scala
+++ b/test/controllers/UnauthorisedControllerSpec.scala
@@ -24,7 +24,7 @@ class UnauthorisedControllerSpec extends SpecBase {
   "onPageLoad" must {
 
     "return OK" in {
-      val app = buildApp
+      val app = application
 
       running(app) {
         val result = route(app, fakeRequest("GET", routes.UnauthorisedController.onPageLoad.url)).value

--- a/test/controllers/UnauthorisedControllerSpec.scala
+++ b/test/controllers/UnauthorisedControllerSpec.scala
@@ -24,10 +24,9 @@ class UnauthorisedControllerSpec extends SpecBase {
   "onPageLoad" must {
 
     "return OK" in {
-      val app = application
 
-      running(app) {
-        val result = route(app, fakeRequest("GET", routes.UnauthorisedController.onPageLoad.url)).value
+      running(application) {
+        val result = route(application, fakeRequest("GET", routes.UnauthorisedController.onPageLoad.url)).value
         status(result) mustEqual OK
       }
     }

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -41,7 +41,7 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to log in " in {
 
-        val app = buildApp
+        val app = application
         val config = app.injector.instanceOf[AppConfig]
 
         val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
@@ -62,7 +62,7 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to log in " in {
 
-        val app = buildApp
+        val app = application
         val config = app.injector.instanceOf[AppConfig]
 
         val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
@@ -83,7 +83,7 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = buildApp
+        val app = application
         val config = app.injector.instanceOf[AppConfig]
 
         val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
@@ -104,7 +104,7 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = buildApp
+        val app = application
         val config = app.injector.instanceOf[AppConfig]
 
         val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
@@ -125,7 +125,7 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = buildApp
+        val app = application
         val config = app.injector.instanceOf[AppConfig]
 
         val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
@@ -146,7 +146,7 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = buildApp
+        val app = application
         val config = app.injector.instanceOf[AppConfig]
 
         val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
@@ -167,7 +167,7 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = buildApp
+        val app = application
         val config = app.injector.instanceOf[AppConfig]
 
         val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -41,10 +41,10 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to log in " in {
 
-        val app = application.build()
+        val app = buildApp
         val config = app.injector.instanceOf[AppConfig]
 
-        val bodyParsers = application.injector().instanceOf[BodyParsers.Default]
+        val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(
           new FakeFailingAuthConnector(new MissingBearerToken), config, bodyParsers)
@@ -62,10 +62,10 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to log in " in {
 
-        val app = application.build()
+        val app = buildApp
         val config = app.injector.instanceOf[AppConfig]
 
-        val bodyParsers = application.injector().instanceOf[BodyParsers.Default]
+        val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(
           new FakeFailingAuthConnector(new BearerTokenExpired), config, bodyParsers)
@@ -83,10 +83,10 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = application.build()
+        val app = buildApp
         val config = app.injector.instanceOf[AppConfig]
 
-        val bodyParsers = application.injector().instanceOf[BodyParsers.Default]
+        val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(
           new FakeFailingAuthConnector(new InsufficientEnrolments), config, bodyParsers)
@@ -104,10 +104,10 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = application.build()
+        val app = buildApp
         val config = app.injector.instanceOf[AppConfig]
 
-        val bodyParsers = application.injector().instanceOf[BodyParsers.Default]
+        val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(
           new FakeFailingAuthConnector(new InsufficientConfidenceLevel), config, bodyParsers)
@@ -125,10 +125,10 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = application.build()
+        val app = buildApp
         val config = app.injector.instanceOf[AppConfig]
 
-        val bodyParsers = application.injector().instanceOf[BodyParsers.Default]
+        val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(
           new FakeFailingAuthConnector(new UnsupportedAuthProvider), config, bodyParsers)
@@ -146,10 +146,10 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = application.build()
+        val app = buildApp
         val config = app.injector.instanceOf[AppConfig]
 
-        val bodyParsers = application.injector().instanceOf[BodyParsers.Default]
+        val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(
           new FakeFailingAuthConnector(new UnsupportedAffinityGroup), config, bodyParsers)
@@ -167,10 +167,10 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = application.build()
+        val app = buildApp
         val config = app.injector.instanceOf[AppConfig]
 
-        val bodyParsers = application.injector().instanceOf[BodyParsers.Default]
+        val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
         val authAction = new AuthenticatedIdentifierAction(
           new FakeFailingAuthConnector(new UnsupportedCredentialRole), config, bodyParsers)

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.Retrieval
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.SpecBase
+import utils.Utils.emptyString
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
@@ -41,8 +42,7 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to log in " in {
 
-        val app = application
-        val config = app.injector.instanceOf[AppConfig]
+        val config = application.injector.instanceOf[AppConfig]
 
         val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
@@ -62,8 +62,7 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to log in " in {
 
-        val app = application
-        val config = app.injector.instanceOf[AppConfig]
+        val config = application.injector.instanceOf[AppConfig]
 
         val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
@@ -83,8 +82,7 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = application
-        val config = app.injector.instanceOf[AppConfig]
+        val config = application.injector.instanceOf[AppConfig]
 
         val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
@@ -104,8 +102,7 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = application
-        val config = app.injector.instanceOf[AppConfig]
+        val config = application.injector.instanceOf[AppConfig]
 
         val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
@@ -125,8 +122,7 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = application
-        val config = app.injector.instanceOf[AppConfig]
+        val config = application.injector.instanceOf[AppConfig]
 
         val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
@@ -146,8 +142,7 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = application
-        val config = app.injector.instanceOf[AppConfig]
+        val config = application.injector.instanceOf[AppConfig]
 
         val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
@@ -167,8 +162,7 @@ class AuthActionSpec extends SpecBase {
 
       "redirect the user to the unauthorised page" in {
 
-        val app = application
-        val config = app.injector.instanceOf[AppConfig]
+        val config = application.injector.instanceOf[AppConfig]
 
         val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
@@ -187,7 +181,7 @@ class AuthActionSpec extends SpecBase {
 }
 
 class FakeFailingAuthConnector @Inject()(exceptionToReturn: Throwable) extends AuthConnector {
-  val serviceUrl: String = ""
+  val serviceUrl: String = emptyString
 
   override def authorise[A](predicate: Predicate, retrieval: Retrieval[A])(
     implicit hc: HeaderCarrier, ec: ExecutionContext): Future[A] = Future.failed(exceptionToReturn)

--- a/test/controllers/actions/EmailActionSpec.scala
+++ b/test/controllers/actions/EmailActionSpec.scala
@@ -87,7 +87,7 @@ class EmailActionSpec extends SpecBase {
     val eori = "GB12345678"
     val mockDataStoreConnector: CustomsDataStoreConnector = mock[CustomsDataStoreConnector]
 
-    val app: Application = application.overrides(
+    val app: Application = applicationBuilder.overrides(
       inject.bind[CustomsDataStoreConnector].toInstance(mockDataStoreConnector)
     ).build()
 

--- a/test/crypto/CashAccountTransactionSearchResponseDetailEncrypterSpec.scala
+++ b/test/crypto/CashAccountTransactionSearchResponseDetailEncrypterSpec.scala
@@ -30,7 +30,6 @@ class CashAccountTransactionSearchResponseDetailEncrypterSpec extends SpecBase {
   private val encrypter = new CashAccountTransactionSearchResponseDetailEncrypter(cipher)
   private val secretKey = "VqmXp7yigDFxbCUdDdNZVIvbW6RgPNJsliv6swQNCL8="
 
-
   "encrypter" must {
 
     "encrypt and decrypt declaration search response detail correctly" in new Setup {
@@ -59,7 +58,7 @@ class CashAccountTransactionSearchResponseDetailEncrypterSpec extends SpecBase {
   trait Setup {
 
     val accNumber = "testCAN"
-    val eoriData = EoriData(eoriNumber = "GB123456789012", name = "Test Importer")
+    val eoriData: EoriData = EoriData(eoriNumber = "GB123456789012", name = "Test Importer")
 
     val declarations: Seq[DeclarationWrapper] = Seq(
       DeclarationWrapper(DeclarationSearch(

--- a/test/crypto/CashTransactionsEncrypterSpec.scala
+++ b/test/crypto/CashTransactionsEncrypterSpec.scala
@@ -74,7 +74,7 @@ class CashTransactionsEncrypterSpec extends SpecBase {
         encrypter.decryptCashTransactions(encryptedCashTransactions, secretKey)
 
       decryptedCashTransactions mustEqual cashTransactions02
-      decryptedCashTransactions.maxTransactionsExceeded mustEqual Some(true)
+      decryptedCashTransactions.maxTransactionsExceeded mustBe Some(true)
     }
 
     "decrypt cashTransactions" in new Setup {

--- a/test/forms/mappings/FormattersSpec.scala
+++ b/test/forms/mappings/FormattersSpec.scala
@@ -16,9 +16,7 @@
 
 package forms.mappings
 
-import play.api.Application
 import play.api.data.FormError
-import play.api.i18n.Messages
 import utils.SpecBase
 
 class FormattersSpec extends SpecBase {

--- a/test/forms/mappings/FormattersSpec.scala
+++ b/test/forms/mappings/FormattersSpec.scala
@@ -67,7 +67,5 @@ class FormattersSpec extends SpecBase {
 
   trait Setup {
     val formatterOb: Formatters = new Formatters {}
-    val app: Application = buildApp
-    implicit val msg: Messages = messages(app)
   }
 }

--- a/test/forms/mappings/FormattersSpec.scala
+++ b/test/forms/mappings/FormattersSpec.scala
@@ -67,7 +67,7 @@ class FormattersSpec extends SpecBase {
 
   trait Setup {
     val formatterOb: Formatters = new Formatters {}
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val msg: Messages = messages(app)
   }
 }

--- a/test/helpers/CashAccountUtilsSpec.scala
+++ b/test/helpers/CashAccountUtilsSpec.scala
@@ -36,7 +36,6 @@ class CashAccountUtilsSpec extends SpecBase {
       bind[DateTimeService].toInstance(mockDateTimeService)
     ).build()
 
-  implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
   val cashAccountUtils: CashAccountUtils = app.injector.instanceOf[CashAccountUtils]
 
   "filenameWithDateTime" should {

--- a/test/helpers/CashAccountUtilsSpec.scala
+++ b/test/helpers/CashAccountUtilsSpec.scala
@@ -31,7 +31,7 @@ class CashAccountUtilsSpec extends SpecBase {
 
   when(mockDateTimeService.localDateTime()).thenReturn(LocalDateTime.parse("2020-04-19T09:30:59"))
 
-  val app: Application = application
+  val app: Application = applicationBuilder
     .overrides(
       bind[DateTimeService].toInstance(mockDateTimeService)
     ).build()

--- a/test/helpers/CashAccountUtilsSpec.scala
+++ b/test/helpers/CashAccountUtilsSpec.scala
@@ -17,9 +17,7 @@
 package helpers
 
 import play.api.Application
-import play.api.i18n.{Messages, MessagesApi}
 import play.api.inject.bind
-import play.api.test.FakeRequest
 import services.DateTimeService
 import utils.SpecBase
 import org.mockito.Mockito.when

--- a/test/helpers/DateFormatSpec.scala
+++ b/test/helpers/DateFormatSpec.scala
@@ -16,7 +16,6 @@
 
 package helpers
 
-import play.api.test.Helpers
 import utils.SpecBase
 
 class DateFormatSpec extends SpecBase {

--- a/test/helpers/DateFormatSpec.scala
+++ b/test/helpers/DateFormatSpec.scala
@@ -16,39 +16,36 @@
 
 package helpers
 
-import play.api.i18n.Messages
 import play.api.test.Helpers
 import utils.SpecBase
 
 class DateFormatSpec extends SpecBase {
 
-  implicit val messages: Messages = Helpers.stubMessages()
-
   "CurrencyFormatters.formatCurrencyAmount" should {
 
     "format a number to the given number of decimals" in {
-      Formatters.formatCurrencyAmount(amount = 999.6565) must be ("£999.66")
+      Formatters.formatCurrencyAmount(amount = 999.6565) must be("£999.66")
     }
 
     "include trailing zero if there is any significant decimal place" in {
-      Formatters.formatCurrencyAmount(amount = 999.1) must be ("£999.10")
+      Formatters.formatCurrencyAmount(amount = 999.1) must be("£999.10")
     }
 
     "include zero decimals if explicitly requested" in {
-      Formatters.formatCurrencyAmount( amount = 999.00) must be ("£999.00")
+      Formatters.formatCurrencyAmount(amount = 999.00) must be("£999.00")
     }
 
     "prefix the amount with the currency symbol for the requested locale" in {
-      Formatters.formatCurrencyAmount(amount = 999.6565) must be ("£999.66")
+      Formatters.formatCurrencyAmount(amount = 999.6565) must be("£999.66")
     }
 
     "include grouping separator where requested" in {
-      Formatters.formatCurrencyAmount(amount = 9999999.99) must be ("£9,999,999.99")
+      Formatters.formatCurrencyAmount(amount = 9999999.99) must be("£9,999,999.99")
     }
 
     "by default" should {
       "format to 2 decimal places, with grouping, for the UK locale" in {
-        Formatters.formatCurrencyAmount(amount = 1999.6565) must be ("£1,999.66")
+        Formatters.formatCurrencyAmount(amount = 1999.6565) must be("£1,999.66")
       }
     }
   }

--- a/test/helpers/FormattersSpec.scala
+++ b/test/helpers/FormattersSpec.scala
@@ -126,7 +126,7 @@ class FormattersSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val msg: Messages = messages(app)
     val date: LocalDate = LocalDate.parse("2020-07-21")
   }

--- a/test/helpers/FormattersSpec.scala
+++ b/test/helpers/FormattersSpec.scala
@@ -18,8 +18,6 @@ package helpers
 
 import helpers.Formatters.*
 import utils.SpecBase
-import play.api.Application
-import play.api.i18n.Messages
 
 import java.time.{LocalDate, LocalDateTime}
 

--- a/test/helpers/FormattersSpec.scala
+++ b/test/helpers/FormattersSpec.scala
@@ -126,8 +126,6 @@ class FormattersSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = buildApp
-    implicit val msg: Messages = messages(app)
     val date: LocalDate = LocalDate.parse("2020-07-21")
   }
 }

--- a/test/helpers/FormattersTest.scala
+++ b/test/helpers/FormattersTest.scala
@@ -16,8 +16,6 @@
 
 package helpers
 
-import play.api.i18n.Messages
-import play.api.test.Helpers
 import utils.SpecBase
 
 class FormattersTest extends SpecBase {

--- a/test/helpers/FormattersTest.scala
+++ b/test/helpers/FormattersTest.scala
@@ -22,8 +22,6 @@ import utils.SpecBase
 
 class FormattersTest extends SpecBase {
 
-  implicit val messages: Messages = Helpers.stubMessages()
-
   "CurrencyFormatters.formatCurrencyAmount" should {
 
     "format a number to the given number of decimals" in {

--- a/test/models/CashStatementsByMonthSpec.scala
+++ b/test/models/CashStatementsByMonthSpec.scala
@@ -61,9 +61,6 @@ class CashStatementsByMonthSpec extends SpecBase {
 
   trait Setup {
 
-    val app: Application = buildApp
-    implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
-
     val year = 2024
     val month = 5
     val day = 1

--- a/test/models/CashStatementsByMonthSpec.scala
+++ b/test/models/CashStatementsByMonthSpec.scala
@@ -61,7 +61,7 @@ class CashStatementsByMonthSpec extends SpecBase {
 
   trait Setup {
 
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
 
     val year = 2024

--- a/test/models/CashStatementsByMonthSpec.scala
+++ b/test/models/CashStatementsByMonthSpec.scala
@@ -18,9 +18,6 @@ package models
 
 import models.metadata.CashStatementFileMetadata
 import java.time.LocalDate
-import play.api.Application
-import play.api.i18n.{Messages, MessagesApi}
-import play.api.test.FakeRequest
 import utils.SpecBase
 
 class CashStatementsByMonthSpec extends SpecBase {

--- a/test/models/CashStatementsForEoriSpec.scala
+++ b/test/models/CashStatementsForEoriSpec.scala
@@ -76,7 +76,7 @@ class CashStatementsForEoriSpec extends SpecBase {
 
   trait Setup {
 
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
 
     val year = 2024

--- a/test/models/CashStatementsForEoriSpec.scala
+++ b/test/models/CashStatementsForEoriSpec.scala
@@ -18,7 +18,6 @@ package models
 
 import models.metadata.CashStatementFileMetadata
 import play.api.Application
-import play.api.i18n.{Messages, MessagesApi}
 import play.api.test.FakeRequest
 import utils.SpecBase
 
@@ -75,9 +74,6 @@ class CashStatementsForEoriSpec extends SpecBase {
   }
 
   trait Setup {
-
-    val app: Application = buildApp
-    implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
 
     val year = 2024
     val month = 5

--- a/test/models/CashStatementsForEoriSpec.scala
+++ b/test/models/CashStatementsForEoriSpec.scala
@@ -17,8 +17,6 @@
 package models
 
 import models.metadata.CashStatementFileMetadata
-import play.api.Application
-import play.api.test.FakeRequest
 import utils.SpecBase
 
 import java.time.LocalDate

--- a/test/models/SdesFileSpec.scala
+++ b/test/models/SdesFileSpec.scala
@@ -17,9 +17,6 @@
 package models
 
 import models.metadata.CashStatementFileMetadata
-import play.api.Application
-import play.api.i18n.{Messages, MessagesApi}
-import play.api.test.FakeRequest
 import utils.SpecBase
 
 import java.time.LocalDate

--- a/test/models/SdesFileSpec.scala
+++ b/test/models/SdesFileSpec.scala
@@ -79,7 +79,7 @@ class SdesFileSpec extends SpecBase {
 
   trait Setup {
 
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
 
     val yearStart = 2024

--- a/test/models/SdesFileSpec.scala
+++ b/test/models/SdesFileSpec.scala
@@ -79,9 +79,6 @@ class SdesFileSpec extends SpecBase {
 
   trait Setup {
 
-    val app: Application = buildApp
-    implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
-
     val yearStart = 2024
     val monthStart = 5
     val dayStart = 5

--- a/test/services/DateTimeServiceSpec.scala
+++ b/test/services/DateTimeServiceSpec.scala
@@ -27,7 +27,7 @@ class DateTimeServiceSpec extends SpecBase {
   "DateTimeService" should {
 
     "return the future date as system date/time when fixed-systemdate-for-tests is enabled" in new Setup {
-      val newApp: GuiceApplicationBuilder = application.configure("features.fixed-systemdate-for-tests" -> true)
+      val newApp: GuiceApplicationBuilder = applicationBuilder.configure("features.fixed-systemdate-for-tests" -> true)
 
       override val appConfig: AppConfig = newApp.injector().instanceOf[AppConfig]
       override val service = new DateTimeService(appConfig)
@@ -37,7 +37,7 @@ class DateTimeServiceSpec extends SpecBase {
     }
 
     "return the future date as local date time when fixed-systemdate-for-tests is enabled" in new Setup {
-      val newApp: GuiceApplicationBuilder = application.configure("features.fixed-systemdate-for-tests" -> true)
+      val newApp: GuiceApplicationBuilder = applicationBuilder.configure("features.fixed-systemdate-for-tests" -> true)
 
       override val appConfig: AppConfig = newApp.injector().instanceOf[AppConfig]
       override val service = new DateTimeService(appConfig)
@@ -47,7 +47,7 @@ class DateTimeServiceSpec extends SpecBase {
     }
 
     "return the future date as utc when fixed-systemdate-for-tests is enabled" in new Setup {
-      val newApp: GuiceApplicationBuilder = application.configure("features.fixed-systemdate-for-tests" -> true)
+      val newApp: GuiceApplicationBuilder = applicationBuilder.configure("features.fixed-systemdate-for-tests" -> true)
 
       override val appConfig: AppConfig = newApp.injector().instanceOf[AppConfig]
       override val service = new DateTimeService(appConfig)
@@ -57,7 +57,7 @@ class DateTimeServiceSpec extends SpecBase {
     }
 
     "return the time now when fixed-systemdate-for-tests is disabled" in new Setup {
-      val newApp: GuiceApplicationBuilder = application.configure("features.fixed-systemdate-for-tests" -> false)
+      val newApp: GuiceApplicationBuilder = applicationBuilder.configure("features.fixed-systemdate-for-tests" -> false)
 
       override val appConfig: AppConfig = newApp.injector().instanceOf[AppConfig]
       override val service = new DateTimeService(appConfig)
@@ -77,7 +77,7 @@ class DateTimeServiceSpec extends SpecBase {
     val fixedTestDateTime: LocalDateTime =
       LocalDateTime.of(LocalDate.of(year, month, day), LocalTime.of(hour, minute))
 
-    val appConfig: AppConfig = application.injector().instanceOf[AppConfig]
+    val appConfig: AppConfig = applicationBuilder.injector().instanceOf[AppConfig]
     val service = new DateTimeService(appConfig)
   }
 }

--- a/test/services/SdesGatekeeperServiceSpec.scala
+++ b/test/services/SdesGatekeeperServiceSpec.scala
@@ -21,8 +21,6 @@ import models.FileRole.CDSCashAccount
 import models.metadata.{CashStatementFileMetadata, Metadata, MetadataItem}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.{times, verify, when}
-import play.api.Application
-import play.api.i18n.Messages
 import utils.SpecBase
 
 class SdesGatekeeperServiceSpec extends SpecBase {

--- a/test/services/SdesGatekeeperServiceSpec.scala
+++ b/test/services/SdesGatekeeperServiceSpec.scala
@@ -32,7 +32,7 @@ class SdesGatekeeperServiceSpec extends SpecBase {
     "convert FileInformation to CashStatementFile correctly" in new Setup {
       val sdesFileInformation: FileInformation = validCashStatementFileInformation
 
-      val result: CashStatementFile = sdesGatekeeperService.convertToCashStatementFile(sdesFileInformation)(msg)
+      val result: CashStatementFile = sdesGatekeeperService.convertToCashStatementFile(sdesFileInformation)(messages)
 
       result.filename mustBe sdesFileInformation.filename
       result.downloadURL mustBe sdesFileInformation.downloadURL
@@ -68,9 +68,6 @@ class SdesGatekeeperServiceSpec extends SpecBase {
   }
 
   trait Setup {
-
-    val app: Application = buildApp
-    implicit val msg: Messages = messages(app)
 
     val sdesGatekeeperService = new SdesGatekeeperService()
     val periodStartYear = 2017

--- a/test/services/SdesGatekeeperServiceSpec.scala
+++ b/test/services/SdesGatekeeperServiceSpec.scala
@@ -69,7 +69,7 @@ class SdesGatekeeperServiceSpec extends SpecBase {
 
   trait Setup {
 
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val msg: Messages = messages(app)
 
     val sdesGatekeeperService = new SdesGatekeeperService()

--- a/test/utils/SpecBase.scala
+++ b/test/utils/SpecBase.scala
@@ -60,7 +60,7 @@ trait SpecBase extends AnyWordSpecLike
                   path: String = emptyString): FakeRequest[AnyContentAsEmpty.type] =
     FakeRequest(method, path).withCSRFToken.asInstanceOf[FakeRequest[AnyContentAsEmpty.type]]
 
-  def messages(app: Application): Messages = app.injector.instanceOf[MessagesApi].preferred(
+  implicit lazy val messages: Messages = buildApp.injector.instanceOf[MessagesApi].preferred(
     fakeRequest(emptyString, emptyString))
 
   implicit lazy val appConfig: AppConfig = applicationBuilder.injector().instanceOf[AppConfig]

--- a/test/utils/SpecBase.scala
+++ b/test/utils/SpecBase.scala
@@ -55,12 +55,12 @@ trait SpecBase extends AnyWordSpecLike
     "play.filters.csp.nonce.enabled" -> "false",
     "auditing.enabled" -> "false")
 
-  lazy val buildApp: Application = applicationBuilder.build()
+  lazy val application: Application = applicationBuilder.build()
   def fakeRequest(method: String = emptyString,
                   path: String = emptyString): FakeRequest[AnyContentAsEmpty.type] =
     FakeRequest(method, path).withCSRFToken.asInstanceOf[FakeRequest[AnyContentAsEmpty.type]]
 
-  implicit lazy val messages: Messages = buildApp.injector.instanceOf[MessagesApi].preferred(
+  implicit lazy val messages: Messages = application.injector.instanceOf[MessagesApi].preferred(
     fakeRequest(emptyString, emptyString))
 
   implicit lazy val appConfig: AppConfig = applicationBuilder.injector().instanceOf[AppConfig]

--- a/test/utils/SpecBase.scala
+++ b/test/utils/SpecBase.scala
@@ -48,13 +48,14 @@ trait SpecBase extends AnyWordSpecLike
   val emptyString = ""
   val sessionId: SessionId = SessionId("session_1234")
 
-  def application: GuiceApplicationBuilder = new GuiceApplicationBuilder().overrides(
+  lazy val applicationBuilder: GuiceApplicationBuilder = new GuiceApplicationBuilder().overrides(
     bind[IdentifierAction].to[FakeIdentifierAction],
     bind[Metrics].toInstance(new FakeMetrics)
   ).configure(
     "play.filters.csp.nonce.enabled" -> "false",
     "auditing.enabled" -> "false")
 
+  lazy val buildApp: Application = applicationBuilder.build()
   def fakeRequest(method: String = emptyString,
                   path: String = emptyString): FakeRequest[AnyContentAsEmpty.type] =
     FakeRequest(method, path).withCSRFToken.asInstanceOf[FakeRequest[AnyContentAsEmpty.type]]
@@ -62,7 +63,7 @@ trait SpecBase extends AnyWordSpecLike
   def messages(app: Application): Messages = app.injector.instanceOf[MessagesApi].preferred(
     fakeRequest(emptyString, emptyString))
 
-  def appConfig(app: Application): AppConfig = app.injector.instanceOf[AppConfig]
+  implicit lazy val appConfig: AppConfig = applicationBuilder.injector().instanceOf[AppConfig]
 
   implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(sessionId))
 }

--- a/test/utils/TestData.scala
+++ b/test/utils/TestData.scala
@@ -47,7 +47,8 @@ object TestData {
   val TAX_TYPE: TaxType = TaxType(Some("a"), "a", AMOUNT)
   val TAX_GROUP: TaxGroup = TaxGroup(ImportVat, AMOUNT, Seq(TAX_TYPE))
 
-  val HREF = "testHref"
+  val TEST_HREF = "testHref"
+  val HREF = "href"
 
   val PAGE_1 = 1
   val PAGE_2 = 2

--- a/test/utils/UtilsSpec.scala
+++ b/test/utils/UtilsSpec.scala
@@ -16,7 +16,6 @@
 
 package utils
 
-import play.api.Application
 import play.twirl.api.{Html, HtmlFormat}
 import uk.gov.hmrc.govukfrontend.views.html.components.GovukTable
 import utils.Utils.*

--- a/test/utils/UtilsSpec.scala
+++ b/test/utils/UtilsSpec.scala
@@ -226,7 +226,7 @@ class UtilsSpec extends SpecBase {
 
   trait Setup {
 
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val msgs: Messages = messages(app)
     implicit val config: AppConfig = app.injector.instanceOf[AppConfig]
 

--- a/test/utils/UtilsSpec.scala
+++ b/test/utils/UtilsSpec.scala
@@ -16,9 +16,7 @@
 
 package utils
 
-import config.AppConfig
 import play.api.Application
-import play.api.i18n.Messages
 import play.twirl.api.{Html, HtmlFormat}
 import uk.gov.hmrc.govukfrontend.views.html.components.GovukTable
 import utils.Utils.*
@@ -225,11 +223,6 @@ class UtilsSpec extends SpecBase {
   }
 
   trait Setup {
-
-    val app: Application = buildApp
-    implicit val msgs: Messages = messages(app)
-    implicit val config: AppConfig = app.injector.instanceOf[AppConfig]
-
     val testMsgKey = "test_key"
     val testMsg = "test_msg"
     val testId = "test_id"

--- a/test/viewmodels/CashAccountDailyStatementsViewModelSpec.scala
+++ b/test/viewmodels/CashAccountDailyStatementsViewModelSpec.scala
@@ -241,7 +241,7 @@ class CashAccountDailyStatementsViewModelSpec extends SpecBase {
 
     val cashTransactions: CashTransactions = CashTransactions(pendingTransactions, dailyStatements)
 
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val msgs: Messages = messages(app)
     implicit val config: AppConfig = app.injector.instanceOf[AppConfig]
   }

--- a/test/viewmodels/CashAccountDailyStatementsViewModelSpec.scala
+++ b/test/viewmodels/CashAccountDailyStatementsViewModelSpec.scala
@@ -16,7 +16,6 @@
 
 package viewmodels
 
-import config.AppConfig
 import models.{CashDailyStatement, CashTransactions, Declaration, Payment, Transaction, Transfer, Withdrawal}
 import helpers.Formatters
 import org.scalatest.Assertion
@@ -240,10 +239,6 @@ class CashAccountDailyStatementsViewModelSpec extends SpecBase {
     val dailyStatements: Seq[CashDailyStatement] = Seq(dailyStatement1, dailyStatement2)
 
     val cashTransactions: CashTransactions = CashTransactions(pendingTransactions, dailyStatements)
-
-    val app: Application = buildApp
-    implicit val msgs: Messages = messages(app)
-    implicit val config: AppConfig = app.injector.instanceOf[AppConfig]
   }
 
 }

--- a/test/viewmodels/CashAccountDailyStatementsViewModelSpec.scala
+++ b/test/viewmodels/CashAccountDailyStatementsViewModelSpec.scala
@@ -19,7 +19,6 @@ package viewmodels
 import models.{CashDailyStatement, CashTransactions, Declaration, Payment, Transaction, Transfer, Withdrawal}
 import helpers.Formatters
 import org.scalatest.Assertion
-import play.api.Application
 import play.api.i18n.Messages
 import utils.SpecBase
 import utils.TestData.*

--- a/test/viewmodels/CashAccountV2ViewModelSpec.scala
+++ b/test/viewmodels/CashAccountV2ViewModelSpec.scala
@@ -255,7 +255,7 @@ class CashAccountV2ViewModelSpec extends SpecBase {
     val size: Long = 300L
     val totalElements = 8
 
-    val app: Application = application.build()
+    val app: Application = buildApp
 
     implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
     implicit val msgs: Messages = messages(app)

--- a/test/viewmodels/CashAccountV2ViewModelSpec.scala
+++ b/test/viewmodels/CashAccountV2ViewModelSpec.scala
@@ -257,9 +257,6 @@ class CashAccountV2ViewModelSpec extends SpecBase {
 
     val app: Application = buildApp
 
-    implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
-    implicit val msgs: Messages = messages(app)
-
     val cashAccount: CashAccount = CashAccount(number = can,
       owner = eoriNumber,
       status = AccountStatusOpen,

--- a/test/viewmodels/CashAccountV2ViewModelSpec.scala
+++ b/test/viewmodels/CashAccountV2ViewModelSpec.scala
@@ -55,7 +55,7 @@ class CashAccountV2ViewModelSpec extends SpecBase {
         shouldProduceCorrectAccountBalance(cashAccountViewModel.cashAccountBalance, eoriNumber, cashAccount)
         shouldProduceCorrectDownloadCSVFileLink(cashAccountViewModel.downloadCSVFileLinkUrl)
         shouldOutputCorrectHelpAndSupportGuidance(cashAccountViewModel.helpAndSupportGuidance)
-        shouldContainCorrectDailyStatementsSection(app, cashAccountViewModel.dailyStatementsSection.get, cashTransactions)
+        shouldContainCorrectDailyStatementsSection(application, cashAccountViewModel.dailyStatementsSection.get, cashTransactions)
       }
 
       "maxTransactionsExceeded is true" in new Setup {
@@ -83,7 +83,7 @@ class CashAccountV2ViewModelSpec extends SpecBase {
         shouldContainNotificationPanel(cashAccountViewModel.cashStatementNotification.get)
         shouldProduceCorrectDownloadCSVFileLink(cashAccountViewModel.downloadCSVFileLinkUrl)
         shouldOutputCorrectHelpAndSupportGuidance(cashAccountViewModel.helpAndSupportGuidance)
-        shouldContainCorrectDailyStatementsSection(app, cashAccountViewModel.dailyStatementsSection.get, cashTransactions)
+        shouldContainCorrectDailyStatementsSection(application, cashAccountViewModel.dailyStatementsSection.get, cashTransactions)
       }
     }
 
@@ -254,8 +254,6 @@ class CashAccountV2ViewModelSpec extends SpecBase {
     val dayEnd: Int = 8
     val size: Long = 300L
     val totalElements = 8
-
-    val app: Application = application
 
     val cashAccount: CashAccount = CashAccount(number = can,
       owner = eoriNumber,

--- a/test/viewmodels/CashAccountV2ViewModelSpec.scala
+++ b/test/viewmodels/CashAccountV2ViewModelSpec.scala
@@ -255,7 +255,7 @@ class CashAccountV2ViewModelSpec extends SpecBase {
     val size: Long = 300L
     val totalElements = 8
 
-    val app: Application = buildApp
+    val app: Application = application
 
     val cashAccount: CashAccount = CashAccount(number = can,
       owner = eoriNumber,

--- a/test/viewmodels/CashTransactionCsvRowSpec.scala
+++ b/test/viewmodels/CashTransactionCsvRowSpec.scala
@@ -17,9 +17,6 @@
 package viewmodels
 
 import models._
-import play.api.Application
-import play.api.i18n.{Messages, MessagesApi}
-import play.api.test.FakeRequest
 import utils.SpecBase
 import viewmodels.CashTransactionCsvRow.DailyStatementCsvRowsViewModel
 

--- a/test/viewmodels/CashTransactionCsvRowSpec.scala
+++ b/test/viewmodels/CashTransactionCsvRowSpec.scala
@@ -232,9 +232,5 @@ class CashTransactionCsvRowSpec extends SpecBase {
       debit = None,
       balance = None
     )
-
-    val app: Application = buildApp
-
-    implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
   }
 }

--- a/test/viewmodels/CashTransactionCsvRowSpec.scala
+++ b/test/viewmodels/CashTransactionCsvRowSpec.scala
@@ -233,7 +233,7 @@ class CashTransactionCsvRowSpec extends SpecBase {
       balance = None
     )
 
-    val app: Application = application.build()
+    val app: Application = buildApp
 
     implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
   }

--- a/test/viewmodels/CashTransactionsViewModelSpec.scala
+++ b/test/viewmodels/CashTransactionsViewModelSpec.scala
@@ -146,6 +146,5 @@ class CashTransactionsViewModelSpec extends SpecBase {
 
     val modelWithNoDailyStatement: CashTransactionsViewModel =
       CashTransactionsViewModel(cashTransactionsWithNoDailyStatement, None)(mockAppConfig)
-
   }
 }

--- a/test/viewmodels/DeclarationDetailSearchViewModelSpec.scala
+++ b/test/viewmodels/DeclarationDetailSearchViewModelSpec.scala
@@ -169,9 +169,6 @@ class DeclarationDetailSearchViewModelSpec extends SpecBase {
       )
     )
 
-    val app: Application = buildApp
-    implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
-
     def extractSummaryData(summaryList: SummaryList): Seq[(String, String)] = {
       summaryList.rows.map { row =>
         (

--- a/test/viewmodels/DeclarationDetailSearchViewModelSpec.scala
+++ b/test/viewmodels/DeclarationDetailSearchViewModelSpec.scala
@@ -169,7 +169,7 @@ class DeclarationDetailSearchViewModelSpec extends SpecBase {
       )
     )
 
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
 
     def extractSummaryData(summaryList: SummaryList): Seq[(String, String)] = {

--- a/test/viewmodels/DeclarationDetailSearchViewModelSpec.scala
+++ b/test/viewmodels/DeclarationDetailSearchViewModelSpec.scala
@@ -18,10 +18,10 @@ package viewmodels
 
 import helpers.Formatters
 import models.*
-import models.response.{DeclarationSearch, TaxGroupSearch, TaxGroupWrapper, TaxTypeWithSecurity, TaxTypeWithSecurityContainer}
-import play.api.Application
-import play.api.i18n.{Messages, MessagesApi}
-import play.api.test.FakeRequest
+import models.response.{
+  DeclarationSearch, TaxGroupSearch, TaxGroupWrapper, TaxTypeWithSecurity,
+  TaxTypeWithSecurityContainer
+}
 import uk.gov
 import uk.gov.hmrc
 import uk.gov.hmrc.govukfrontend

--- a/test/viewmodels/DeclarationDetailViewModelSpec.scala
+++ b/test/viewmodels/DeclarationDetailViewModelSpec.scala
@@ -210,8 +210,5 @@ class DeclarationDetailViewModelSpec extends SpecBase {
     )
 
     def normalizeHtml(html: String): String = html.replaceAll("\\s+", singleSpace).trim
-
-    val app: Application = buildApp
-    implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
   }
 }

--- a/test/viewmodels/DeclarationDetailViewModelSpec.scala
+++ b/test/viewmodels/DeclarationDetailViewModelSpec.scala
@@ -20,7 +20,6 @@ import helpers.Formatters
 import models.domain.EORI
 import models.{CustomsDuty, Declaration, ExciseDuty, ImportVat, TaxGroup, TaxType}
 import org.mockito.Mockito.*
-import play.api.i18n.{Messages, MessagesApi}
 import uk.gov.hmrc.govukfrontend
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views
@@ -28,8 +27,6 @@ import utils.SpecBase
 import utils.Utils.singleSpace
 
 import java.time.LocalDate
-import play.api.Application
-import play.api.test.FakeRequest
 import uk.gov
 import uk.gov.hmrc
 import uk.gov.hmrc.govukfrontend.views.Aliases

--- a/test/viewmodels/DeclarationDetailViewModelSpec.scala
+++ b/test/viewmodels/DeclarationDetailViewModelSpec.scala
@@ -211,7 +211,7 @@ class DeclarationDetailViewModelSpec extends SpecBase {
 
     def normalizeHtml(html: String): String = html.replaceAll("\\s+", singleSpace).trim
 
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
   }
 }

--- a/test/viewmodels/PaymentSearchResultStatementsViewModelSpec.scala
+++ b/test/viewmodels/PaymentSearchResultStatementsViewModelSpec.scala
@@ -50,7 +50,7 @@ class PaymentSearchResultStatementsViewModelSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val msgs: Messages = messages(app)
     implicit val config: AppConfig = app.injector.instanceOf[AppConfig]
   }

--- a/test/viewmodels/PaymentSearchResultStatementsViewModelSpec.scala
+++ b/test/viewmodels/PaymentSearchResultStatementsViewModelSpec.scala
@@ -16,9 +16,6 @@
 
 package viewmodels
 
-import config.AppConfig
-import play.api.Application
-import play.api.i18n.Messages
 import utils.SpecBase
 import utils.TestData.*
 
@@ -28,7 +25,7 @@ class PaymentSearchResultStatementsViewModelSpec extends SpecBase {
 
     "return viewModel object with correct content" when {
 
-      "cash transactions are available" in new Setup {
+      "cash transactions are available" in {
         val viewModel01: PaymentSearchResultStatementsViewModel =
           PaymentSearchResultStatementsViewModel(SEQ_OF_PAYMENT_DETAILS_01, None)
 
@@ -38,7 +35,7 @@ class PaymentSearchResultStatementsViewModelSpec extends SpecBase {
         viewModel01.noTransactionsMessage mustBe None
       }
 
-      "cash transactions are not present" in new Setup {
+      "cash transactions are not present" in {
         val viewModel02: PaymentSearchResultStatementsViewModel =
           PaymentSearchResultStatementsViewModel(Seq.empty, None)
 
@@ -49,9 +46,4 @@ class PaymentSearchResultStatementsViewModelSpec extends SpecBase {
     }
   }
 
-  trait Setup {
-    val app: Application = buildApp
-    implicit val msgs: Messages = messages(app)
-    implicit val config: AppConfig = app.injector.instanceOf[AppConfig]
-  }
 }

--- a/test/viewmodels/PaymentSearchResultsViewModelSpec.scala
+++ b/test/viewmodels/PaymentSearchResultsViewModelSpec.scala
@@ -137,7 +137,7 @@ class PaymentSearchResultsViewModelSpec extends SpecBase {
     val can: String = "12345678"
     val balance: BigDecimal = BigDecimal(8788.00)
 
-    val app: Application = application.build()
+    val app: Application = buildApp
 
     implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
     implicit val msgs: Messages = messages(app)

--- a/test/viewmodels/PaymentSearchResultsViewModelSpec.scala
+++ b/test/viewmodels/PaymentSearchResultsViewModelSpec.scala
@@ -137,11 +137,6 @@ class PaymentSearchResultsViewModelSpec extends SpecBase {
     val can: String = "12345678"
     val balance: BigDecimal = BigDecimal(8788.00)
 
-    val app: Application = buildApp
-
-    implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
-    implicit val msgs: Messages = messages(app)
-
     val cashAccount: CashAccount = CashAccount(number = can, owner = eoriNumber,
       status = AccountStatusOpen, balances = CDSCashBalance(Some(balance)))
   }

--- a/test/viewmodels/PaymentSearchResultsViewModelSpec.scala
+++ b/test/viewmodels/PaymentSearchResultsViewModelSpec.scala
@@ -19,7 +19,6 @@ package viewmodels
 import config.AppConfig
 import models.*
 import org.scalatest.Assertion
-import play.api.Application
 import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import utils.SpecBase

--- a/test/viewmodels/RequestedTooManyTransactionsViewModelSpec.scala
+++ b/test/viewmodels/RequestedTooManyTransactionsViewModelSpec.scala
@@ -76,7 +76,7 @@ class RequestedTooManyTransactionsViewModelSpec extends SpecBase {
     val toDate: LocalDate = LocalDate.parse("2020-07-20")
     val selectedTxnUrl: String = controllers.routes.SelectedTransactionsController.onPageLoad().url
 
-    val app: Application = application.build()
+    val app: Application = buildApp
 
     implicit val msgs: Messages = messages(app)
   }

--- a/test/viewmodels/RequestedTooManyTransactionsViewModelSpec.scala
+++ b/test/viewmodels/RequestedTooManyTransactionsViewModelSpec.scala
@@ -18,7 +18,6 @@ package viewmodels
 
 import controllers.routes
 import org.scalatest.Assertion
-import play.api.Application
 import play.api.i18n.Messages
 import utils.SpecBase
 import java.time.LocalDate

--- a/test/viewmodels/RequestedTooManyTransactionsViewModelSpec.scala
+++ b/test/viewmodels/RequestedTooManyTransactionsViewModelSpec.scala
@@ -71,13 +71,8 @@ class RequestedTooManyTransactionsViewModelSpec extends SpecBase {
   }
 
   trait Setup {
-
     val fromDate: LocalDate = LocalDate.parse("2020-07-18")
     val toDate: LocalDate = LocalDate.parse("2020-07-20")
     val selectedTxnUrl: String = controllers.routes.SelectedTransactionsController.onPageLoad().url
-
-    val app: Application = buildApp
-
-    implicit val msgs: Messages = messages(app)
   }
 }

--- a/test/viewmodels/ResultsPageSummarySpec.scala
+++ b/test/viewmodels/ResultsPageSummarySpec.scala
@@ -149,10 +149,6 @@ class ResultsPageSummarySpec extends SpecBase {
     val fromDate: LocalDate = LocalDate.of(year, month3rd, day8th)
     val toDate: LocalDate = LocalDate.of(year, month4th, day10th)
 
-    val app: Application = buildApp
-
-    implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
-
     val resultPageSummary01: ResultsPageSummary = new ResultsPageSummary(fromDate, toDate, true)
     val resultPageSummary02: ResultsPageSummary = new ResultsPageSummary(fromDate, toDate, false)
   }

--- a/test/viewmodels/ResultsPageSummarySpec.scala
+++ b/test/viewmodels/ResultsPageSummarySpec.scala
@@ -149,7 +149,7 @@ class ResultsPageSummarySpec extends SpecBase {
     val fromDate: LocalDate = LocalDate.of(year, month3rd, day8th)
     val toDate: LocalDate = LocalDate.of(year, month4th, day10th)
 
-    val app: Application = application.build()
+    val app: Application = buildApp
 
     implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
 

--- a/test/viewmodels/ResultsPageSummarySpec.scala
+++ b/test/viewmodels/ResultsPageSummarySpec.scala
@@ -17,9 +17,6 @@
 package viewmodels
 
 import org.scalatest.Assertion
-import play.api.Application
-import play.api.i18n.{Messages, MessagesApi}
-import play.api.test.FakeRequest
 import utils.SpecBase
 
 import java.time.LocalDate

--- a/test/viewmodels/pagination/ListPaginationViewModelSpec.scala
+++ b/test/viewmodels/pagination/ListPaginationViewModelSpec.scala
@@ -227,8 +227,7 @@ class ListPaginationViewModelSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
-    implicit val config: AppConfig = appConfig(app)
+    val app: Application = buildApp
     implicit val msgs: Messages = messages(app)
 
     val testHref = "href"

--- a/test/viewmodels/pagination/ListPaginationViewModelSpec.scala
+++ b/test/viewmodels/pagination/ListPaginationViewModelSpec.scala
@@ -16,9 +16,6 @@
 
 package viewmodels.pagination
 
-import config.AppConfig
-import play.api.Application
-import play.api.i18n.Messages
 import utils.SpecBase
 import uk.gov.hmrc.govukfrontend.views.viewmodels.pagination.{Pagination, PaginationItem}
 import utils.TestData.{

--- a/test/viewmodels/pagination/ListPaginationViewModelSpec.scala
+++ b/test/viewmodels/pagination/ListPaginationViewModelSpec.scala
@@ -22,7 +22,7 @@ import play.api.i18n.Messages
 import utils.SpecBase
 import uk.gov.hmrc.govukfrontend.views.viewmodels.pagination.{Pagination, PaginationItem}
 import utils.TestData.{
-  HREF, PAGE_1, PAGE_10, PAGE_100, PAGE_1000, PAGE_2, PAGE_200, PAGE_230, PAGE_30, PAGE_300,
+  TEST_HREF, HREF, PAGE_1, PAGE_10, PAGE_100, PAGE_1000, PAGE_2, PAGE_200, PAGE_230, PAGE_30, PAGE_300,
   PAGE_4, PAGE_450, PAGE_451, PAGE_460, PAGE_5, PAGE_600, PAGE_650, PAGE_720, PAGE_80, PAGE_800, PAGE_880,
   PAGE_98, PAGE_99
 }
@@ -32,51 +32,51 @@ class ListPaginationViewModelSpec extends SpecBase {
   "apply.next" should {
 
     "return some value when total items are more than 450 and" +
-      " current page is less than the total number of pages" in new Setup {
-      ListPaginationViewModel(PAGE_460, PAGE_2, PAGE_2, HREF).next.isDefined mustBe true
+      " current page is less than the total number of pages" in {
+      ListPaginationViewModel(PAGE_460, PAGE_2, PAGE_2, TEST_HREF).next.isDefined mustBe true
     }
 
-    "return None when current page is not less than the total number of pages" in new Setup {
-      ListPaginationViewModel(PAGE_10, PAGE_5, PAGE_2, HREF).next.isDefined mustBe false
+    "return None when current page is not less than the total number of pages" in {
+      ListPaginationViewModel(PAGE_10, PAGE_5, PAGE_2, TEST_HREF).next.isDefined mustBe false
     }
 
-    "return None when no of records is equal to or less than 450" in new Setup {
-      ListPaginationViewModel(PAGE_10, PAGE_5, PAGE_2, HREF).next.isDefined mustBe false
-      ListPaginationViewModel(PAGE_450, PAGE_5, PAGE_2, HREF).next.isDefined mustBe false
+    "return None when no of records is equal to or less than 450" in {
+      ListPaginationViewModel(PAGE_10, PAGE_5, PAGE_2, TEST_HREF).next.isDefined mustBe false
+      ListPaginationViewModel(PAGE_450, PAGE_5, PAGE_2, TEST_HREF).next.isDefined mustBe false
     }
 
-    "return some value when no of records is greater than 450" in new Setup {
-      ListPaginationViewModel(PAGE_451, PAGE_5, PAGE_2, HREF).next.isDefined mustBe true
-      ListPaginationViewModel(PAGE_600, PAGE_230, PAGE_2, HREF).next.isDefined mustBe true
-      ListPaginationViewModel(PAGE_880, PAGE_80, PAGE_2, HREF).next.isDefined mustBe true
+    "return some value when no of records is greater than 450" in {
+      ListPaginationViewModel(PAGE_451, PAGE_5, PAGE_2, TEST_HREF).next.isDefined mustBe true
+      ListPaginationViewModel(PAGE_600, PAGE_230, PAGE_2, TEST_HREF).next.isDefined mustBe true
+      ListPaginationViewModel(PAGE_880, PAGE_80, PAGE_2, TEST_HREF).next.isDefined mustBe true
     }
   }
 
   "apply.previous" should {
 
-    "return some value when total items are more than 450 and current page is greater than 1" in new Setup {
-      ListPaginationViewModel(PAGE_720, PAGE_100, PAGE_2, HREF).previous.isDefined mustBe true
+    "return some value when total items are more than 450 and current page is greater than 1" in {
+      ListPaginationViewModel(PAGE_720, PAGE_100, PAGE_2, TEST_HREF).previous.isDefined mustBe true
     }
 
-    "return None when total items are more than 450 and current page is not greater than 1" in new Setup {
-      ListPaginationViewModel(PAGE_650, PAGE_1, PAGE_2, HREF).previous.isDefined mustBe false
+    "return None when total items are more than 450 and current page is not greater than 1" in {
+      ListPaginationViewModel(PAGE_650, PAGE_1, PAGE_2, TEST_HREF).previous.isDefined mustBe false
     }
 
-    "return None when no of records is equal to or less than 450" in new Setup {
-      ListPaginationViewModel(PAGE_10, PAGE_1, PAGE_2, HREF).previous.isDefined mustBe false
-      ListPaginationViewModel(PAGE_450, PAGE_100, PAGE_2, HREF).previous.isDefined mustBe false
-      ListPaginationViewModel(PAGE_300, PAGE_200, PAGE_2, HREF).previous.isDefined mustBe false
+    "return None when no of records is equal to or less than 450" in {
+      ListPaginationViewModel(PAGE_10, PAGE_1, PAGE_2, TEST_HREF).previous.isDefined mustBe false
+      ListPaginationViewModel(PAGE_450, PAGE_100, PAGE_2, TEST_HREF).previous.isDefined mustBe false
+      ListPaginationViewModel(PAGE_300, PAGE_200, PAGE_2, TEST_HREF).previous.isDefined mustBe false
     }
 
-    "return some value when no of records is greater than 450" in new Setup {
-      ListPaginationViewModel(PAGE_451, PAGE_100, PAGE_2, HREF).previous.isDefined mustBe true
-      ListPaginationViewModel(PAGE_800, PAGE_5, PAGE_2, HREF).previous.isDefined mustBe true
+    "return some value when no of records is greater than 450" in {
+      ListPaginationViewModel(PAGE_451, PAGE_100, PAGE_2, TEST_HREF).previous.isDefined mustBe true
+      ListPaginationViewModel(PAGE_800, PAGE_5, PAGE_2, TEST_HREF).previous.isDefined mustBe true
     }
   }
 
   "apply.items" should {
-    "return [1] 2 … 100 when on page 1 of 100" in new Setup {
-      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_1000, PAGE_1, PAGE_10, testHref).items
+    "return [1] 2 … 100 when on page 1 of 100" in {
+      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_1000, PAGE_1, PAGE_10, HREF).items
 
       result mustBe Seq(
         PaginationItem(s"href?page=1", Some("1"), current = Some(true)),
@@ -86,8 +86,8 @@ class ListPaginationViewModelSpec extends SpecBase {
       )
     }
 
-    "return 1 [2] 3 … 100 when on page 2 of 100" in new Setup {
-      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_1000, PAGE_2, PAGE_10, testHref).items
+    "return 1 [2] 3 … 100 when on page 2 of 100" in {
+      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_1000, PAGE_2, PAGE_10, HREF).items
 
       result mustBe Seq(
         PaginationItem(s"href?page=1", Some("1"), current = Some(false)),
@@ -98,8 +98,8 @@ class ListPaginationViewModelSpec extends SpecBase {
       )
     }
 
-    "return 1 2 [3] 4 … 100 when on page 3 of 100" in new Setup {
-      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_1000, 3, PAGE_10, testHref).items
+    "return 1 2 [3] 4 … 100 when on page 3 of 100" in {
+      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_1000, 3, PAGE_10, HREF).items
 
       result mustBe Seq(
         PaginationItem(s"href?page=1", Some("1"), current = Some(false)),
@@ -111,8 +111,8 @@ class ListPaginationViewModelSpec extends SpecBase {
       )
     }
 
-    "return 1 … 3 [4] 5 … 100 when on page 4 of 100" in new Setup {
-      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_1000, PAGE_4, PAGE_10, testHref).items
+    "return 1 … 3 [4] 5 … 100 when on page 4 of 100" in {
+      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_1000, PAGE_4, PAGE_10, HREF).items
 
       result mustBe Seq(
         PaginationItem(s"href?page=1", Some("1"), current = Some(false)),
@@ -125,8 +125,8 @@ class ListPaginationViewModelSpec extends SpecBase {
       )
     }
 
-    "return 1 … 97 [98] 99 100 when on page 98 of 100" in new Setup {
-      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_1000, PAGE_98, PAGE_10, testHref).items
+    "return 1 … 97 [98] 99 100 when on page 98 of 100" in {
+      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_1000, PAGE_98, PAGE_10, HREF).items
 
       result mustBe Seq(
         PaginationItem(s"href?page=1", Some("1"), current = Some(false)),
@@ -138,8 +138,8 @@ class ListPaginationViewModelSpec extends SpecBase {
       )
     }
 
-    "return 1 … 98 [99] 100 when on page 99 of 100" in new Setup {
-      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_1000, PAGE_99, PAGE_10, testHref).items
+    "return 1 … 98 [99] 100 when on page 99 of 100" in {
+      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_1000, PAGE_99, PAGE_10, HREF).items
 
       result mustBe Seq(
         PaginationItem(s"href?page=1", Some("1"), current = Some(false)),
@@ -150,8 +150,8 @@ class ListPaginationViewModelSpec extends SpecBase {
       )
     }
 
-    "return 1 … 99 [100] when on page 100 of 100" in new Setup {
-      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_1000, PAGE_100, PAGE_10, testHref).items
+    "return 1 … 99 [100] when on page 100 of 100" in {
+      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_1000, PAGE_100, PAGE_10, HREF).items
 
       result mustBe Seq(
         PaginationItem(s"href?page=1", Some("1"), current = Some(false)),
@@ -161,8 +161,8 @@ class ListPaginationViewModelSpec extends SpecBase {
       )
     }
 
-    "return 1 [2] 3 when on page 2 of 3" in new Setup {
-      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_30, PAGE_2, PAGE_10, testHref).items
+    "return 1 [2] 3 when on page 2 of 3" in {
+      val result: Seq[PaginationItem] = ListPaginationViewModel(PAGE_30, PAGE_2, PAGE_10, HREF).items
 
       result mustBe Seq(
         PaginationItem(s"href?page=1", Some("1"), current = Some(false)),
@@ -176,24 +176,24 @@ class ListPaginationViewModelSpec extends SpecBase {
 
     "return correct output" when {
 
-      "searchParam has some value" in new Setup {
-        ListPaginationViewModel(PAGE_30, PAGE_2, PAGE_1, testHref).searchResult(Some("2")) mustBe
-          msgs("pagination.number-of-movements.plural.with-search-param", "<strong>30</strong>", "2")
+      "searchParam has some value" in {
+        ListPaginationViewModel(PAGE_30, PAGE_2, PAGE_1, HREF).searchResult(Some("2")) mustBe
+          messages("pagination.number-of-movements.plural.with-search-param", "<strong>30</strong>", "2")
       }
 
-      "searchParam has some value and results count is 1" in new Setup {
-        ListPaginationViewModel(PAGE_1, PAGE_2, PAGE_1, testHref).searchResult(Some("2")) mustBe
-          msgs("pagination.number-of-movements.singular.with-search-param", "<strong>1</strong>", "2")
+      "searchParam has some value and results count is 1" in {
+        ListPaginationViewModel(PAGE_1, PAGE_2, PAGE_1, HREF).searchResult(Some("2")) mustBe
+          messages("pagination.number-of-movements.singular.with-search-param", "<strong>1</strong>", "2")
       }
 
-      "searchParam is None" in new Setup {
-        ListPaginationViewModel(PAGE_30, PAGE_2, PAGE_1, testHref).searchResult() mustBe
-          msgs("pagination.number-of-movements.plural", "<strong>30</strong>")
+      "searchParam is None" in {
+        ListPaginationViewModel(PAGE_30, PAGE_2, PAGE_1, HREF).searchResult() mustBe
+          messages("pagination.number-of-movements.plural", "<strong>30</strong>")
       }
 
-      "searchParam is None and results count is 1" in new Setup {
-        ListPaginationViewModel(PAGE_1, PAGE_2, PAGE_1, testHref).searchResult() mustBe
-          msgs("pagination.number-of-movements.singular", "<strong>1</strong>")
+      "searchParam is None and results count is 1" in {
+        ListPaginationViewModel(PAGE_1, PAGE_2, PAGE_1, HREF).searchResult() mustBe
+          messages("pagination.number-of-movements.singular", "<strong>1</strong>")
       }
     }
   }
@@ -202,22 +202,22 @@ class ListPaginationViewModelSpec extends SpecBase {
 
     "return correct output" when {
 
-      "searchParam has some value" in new Setup {
-        ListPaginationViewModel(PAGE_30, PAGE_2, PAGE_1, testHref).paginatedSearchResult(Some("2")) mustBe
-          msgs("pagination.results.search", "<strong>2</strong>", "<strong>2</strong>", "<strong>30</strong>", "2")
+      "searchParam has some value" in {
+        ListPaginationViewModel(PAGE_30, PAGE_2, PAGE_1, HREF).paginatedSearchResult(Some("2")) mustBe
+          messages("pagination.results.search", "<strong>2</strong>", "<strong>2</strong>", "<strong>30</strong>", "2")
       }
 
-      "searchParam is None" in new Setup {
-        ListPaginationViewModel(PAGE_30, PAGE_2, PAGE_1, testHref).paginatedSearchResult() mustBe
-          msgs("pagination.results", "<strong>2</strong>", "<strong>2</strong>", "<strong>30</strong>")
+      "searchParam is None" in {
+        ListPaginationViewModel(PAGE_30, PAGE_2, PAGE_1, HREF).paginatedSearchResult() mustBe
+          messages("pagination.results", "<strong>2</strong>", "<strong>2</strong>", "<strong>30</strong>")
       }
     }
   }
 
   "pagination" should {
 
-    "return correct output" in new Setup {
-      ListPaginationViewModel(PAGE_2, PAGE_2, PAGE_1, testHref).pagination mustBe
+    "return correct output" in {
+      ListPaginationViewModel(PAGE_2, PAGE_2, PAGE_1, HREF).pagination mustBe
         Pagination(Some(
           Seq(
             PaginationItem("href?page=1", Some("1"), None, Some(false), None, Map()),
@@ -226,10 +226,4 @@ class ListPaginationViewModelSpec extends SpecBase {
     }
   }
 
-  trait Setup {
-    val app: Application = buildApp
-    implicit val msgs: Messages = messages(app)
-
-    val testHref = "href"
-  }
 }

--- a/test/views/CashAccountDeclarationDetailsSearchNoResultSpec.scala
+++ b/test/views/CashAccountDeclarationDetailsSearchNoResultSpec.scala
@@ -63,7 +63,7 @@ class CashAccountDeclarationDetailsSearchNoResultSpec extends SpecBase with Guid
     val searchResultParagraph1 = ComponentDetailsForAssertion(
       testDescription = "display correct search result guidance's first paragraph",
       id = Some("search-result-guidance-not-returned-any-results"),
-      expectedValue = s"Your search \"$searchInput\" has not returned any results.")
+      expectedValue = s"""Your search \"$searchInput\" has not returned any results.""")
 
     val searchResultParagraph2 = ComponentDetailsForAssertion(
       testDescription = "display correct search result guidance's second paragraph",

--- a/test/views/CashAccountNoTransactionsSpec.scala
+++ b/test/views/CashAccountNoTransactionsSpec.scala
@@ -143,7 +143,7 @@ class CashAccountNoTransactionsSpec extends SpecBase {
 
     val model: CashAccountViewModel = CashAccountViewModel(eori, cashAccount)
 
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val config: AppConfig = app.injector.instanceOf[AppConfig]
     implicit val msgs: Messages = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest()

--- a/test/views/CashAccountNoTransactionsSpec.scala
+++ b/test/views/CashAccountNoTransactionsSpec.scala
@@ -21,7 +21,6 @@ import models.{AccountStatusOpen, CDSCashBalance, CashAccount, CashAccountViewMo
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.Assertion
-import play.api.Application
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest

--- a/test/views/CashAccountNoTransactionsSpec.scala
+++ b/test/views/CashAccountNoTransactionsSpec.scala
@@ -143,11 +143,10 @@ class CashAccountNoTransactionsSpec extends SpecBase {
 
     val model: CashAccountViewModel = CashAccountViewModel(eori, cashAccount)
 
-    val app: Application = application
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest()
 
     def view(accountModel: CashAccountViewModel): Document =
-      Jsoup.parse(app.injector.instanceOf[cash_account_no_transactions].apply(accountModel).body)
+      Jsoup.parse(application.injector.instanceOf[cash_account_no_transactions].apply(accountModel).body)
 
     val viewDoc: Document = view(model)
   }

--- a/test/views/CashAccountNoTransactionsSpec.scala
+++ b/test/views/CashAccountNoTransactionsSpec.scala
@@ -143,7 +143,7 @@ class CashAccountNoTransactionsSpec extends SpecBase {
 
     val model: CashAccountViewModel = CashAccountViewModel(eori, cashAccount)
 
-    val app: Application = buildApp
+    val app: Application = application
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest()
 
     def view(accountModel: CashAccountViewModel): Document =

--- a/test/views/CashAccountNoTransactionsSpec.scala
+++ b/test/views/CashAccountNoTransactionsSpec.scala
@@ -144,8 +144,6 @@ class CashAccountNoTransactionsSpec extends SpecBase {
     val model: CashAccountViewModel = CashAccountViewModel(eori, cashAccount)
 
     val app: Application = buildApp
-    implicit val config: AppConfig = app.injector.instanceOf[AppConfig]
-    implicit val msgs: Messages = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest()
 
     def view(accountModel: CashAccountViewModel): Document =

--- a/test/views/FooterLinksSpec.scala
+++ b/test/views/FooterLinksSpec.scala
@@ -27,17 +27,11 @@ class FooterLinksSpec extends SpecBase {
 
     "return correct list of FooterItems" when {
 
-      "matching message key is present for FooterItems" in new Setup {
+      "matching message key is present for FooterItems" in {
 
-        FooterLinks()(msgs, config).size mustBe 4
+        FooterLinks()(messages, appConfig).size mustBe 4
       }
     }
   }
 
-  trait Setup {
-    val app: Application = buildApp
-
-    implicit val msgs: Messages = messages(app)
-    implicit val config: AppConfig = app.injector.instanceOf[AppConfig]
-  }
 }

--- a/test/views/FooterLinksSpec.scala
+++ b/test/views/FooterLinksSpec.scala
@@ -35,7 +35,7 @@ class FooterLinksSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
+    val app: Application = buildApp
 
     implicit val msgs: Messages = messages(app)
     implicit val config: AppConfig = app.injector.instanceOf[AppConfig]

--- a/test/views/FooterLinksSpec.scala
+++ b/test/views/FooterLinksSpec.scala
@@ -16,9 +16,6 @@
 
 package views
 
-import config.AppConfig
-import play.api.Application
-import play.api.i18n.Messages
 import utils.SpecBase
 
 class FooterLinksSpec extends SpecBase {
@@ -28,7 +25,6 @@ class FooterLinksSpec extends SpecBase {
     "return correct list of FooterItems" when {
 
       "matching message key is present for FooterItems" in {
-
         FooterLinks()(messages, appConfig).size mustBe 4
       }
     }

--- a/test/views/LayoutSpec.scala
+++ b/test/views/LayoutSpec.scala
@@ -110,7 +110,7 @@ class LayoutSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
+    val app: Application = buildApp
 
     implicit val msgs: Messages = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest("GET", "test_path")

--- a/test/views/LayoutSpec.scala
+++ b/test/views/LayoutSpec.scala
@@ -19,7 +19,6 @@ package views
 import config.AppConfig
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.Application
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest

--- a/test/views/LayoutSpec.scala
+++ b/test/views/LayoutSpec.scala
@@ -112,9 +112,7 @@ class LayoutSpec extends SpecBase {
   trait Setup {
     val app: Application = buildApp
 
-    implicit val msgs: Messages = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest("GET", "test_path")
-    implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
 
     val content: Html = Html("test")
   }

--- a/test/views/LayoutSpec.scala
+++ b/test/views/LayoutSpec.scala
@@ -38,7 +38,7 @@ class LayoutSpec extends SpecBase {
         val title = "test_title"
         val linkUrl = "test.com"
 
-        val layoutView: Document = Jsoup.parse(app.injector.instanceOf[Layout].apply(
+        val layoutView: Document = Jsoup.parse(application.injector.instanceOf[Layout].apply(
           pageTitle = Some(title),
           backLink = Some(linkUrl),
           fullWidth = true
@@ -51,7 +51,7 @@ class LayoutSpec extends SpecBase {
       }
 
       "there is no value for title and back link" in new Setup {
-        val layoutView: Document = Jsoup.parse(app.injector.instanceOf[Layout].apply(
+        val layoutView: Document = Jsoup.parse(application.injector.instanceOf[Layout].apply(
           fullWidth = true)(content).body)
 
         shouldContainCorrectTitle(layoutView)
@@ -63,7 +63,7 @@ class LayoutSpec extends SpecBase {
 
 
     "display correct page-not-working-properly link (desk-pro) and margin" in new Setup {
-      val layoutView: Document = Jsoup.parse(app.injector.instanceOf[Layout].apply(fullWidth = true)(content).body)
+      val layoutView: Document = Jsoup.parse(application.injector.instanceOf[Layout].apply(fullWidth = true)(content).body)
 
       shouldContainCorrectHMRCTechnicalHelper(layoutView)
     }
@@ -110,10 +110,7 @@ class LayoutSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application
-
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest("GET", "test_path")
-
     val content: Html = Html("test")
   }
 }

--- a/test/views/LayoutSpec.scala
+++ b/test/views/LayoutSpec.scala
@@ -110,7 +110,7 @@ class LayoutSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = buildApp
+    val app: Application = application
 
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest("GET", "test_path")
 

--- a/test/views/UnauthorisedSpec.scala
+++ b/test/views/UnauthorisedSpec.scala
@@ -56,6 +56,6 @@ class UnauthorisedSpec extends SpecBase {
 
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
-    val view: Document = Jsoup.parse(buildApp.injector.instanceOf[unauthorised].apply().body)
+    val view: Document = Jsoup.parse(application.injector.instanceOf[unauthorised].apply().body)
   }
 }

--- a/test/views/UnauthorisedSpec.scala
+++ b/test/views/UnauthorisedSpec.scala
@@ -57,7 +57,7 @@ class UnauthorisedSpec extends SpecBase {
     val deskProLinkText = "Is this page not working properly? (opens in new tab)"
     val cdsSubscribeUrl = "https://www.tax.service.gov.uk/customs-enrolment-services/cds/subscribe"
 
-    val app: Application = application.build()
+    val app: Application = buildApp
 
     implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
     implicit val msg: Messages = messages(app)

--- a/test/views/UnauthorisedSpec.scala
+++ b/test/views/UnauthorisedSpec.scala
@@ -16,12 +16,9 @@
 
 package views
 
-import config.AppConfig
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
-import play.api.Application
-import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import utils.SpecBase

--- a/test/views/UnauthorisedSpec.scala
+++ b/test/views/UnauthorisedSpec.scala
@@ -33,21 +33,21 @@ class UnauthorisedSpec extends SpecBase {
 
     "display correct title and guidance" in new Setup {
       view.title() mustBe
-        s"${messages(app)("cf.not-subscribed-to-cds.detail.title")} - ${messages(app)("service.name")} - GOV.UK"
+        s"${messages("cf.not-subscribed-to-cds.detail.title")} - ${messages("service.name")} - GOV.UK"
 
-      view.getElementsByTag("h1").html() mustBe messages(app)("cf.not-subscribed-to-cds.detail.heading")
+      view.getElementsByTag("h1").html() mustBe messages("cf.not-subscribed-to-cds.detail.heading")
 
       view.getElementById("already-subscribed-heading").html() mustBe
-        messages(app)("cf.not-subscribed-to-cds.detail.already-subscribed-to-cds")
+        messages("cf.not-subscribed-to-cds.detail.already-subscribed-to-cds")
       view.getElementById("subscribed-to-cds-heading").html() mustBe
-        messages(app)("cf.not-subscribed-to-cds.details.subscribe-to-cds")
+        messages("cf.not-subscribed-to-cds.details.subscribe-to-cds")
 
       val pElements: Elements = view.getElementsByTag("p")
       pElements.get(1).html() mustBe
-        messages(app)("cf.not-subscribed-to-cds.detail.already-subscribed-to-cds-guidance-text")
+        messages("cf.not-subscribed-to-cds.detail.already-subscribed-to-cds-guidance-text")
 
       view.html().contains(cdsSubscribeUrl)
-      view.html().contains(messages(app)("cf.not-subscribed-to-cds.details.subscribe-to-cds-link-text"))
+      view.html().contains(messages("cf.not-subscribed-to-cds.details.subscribe-to-cds-link-text"))
 
       view.html().contains(deskProLinkText)
     }
@@ -57,13 +57,8 @@ class UnauthorisedSpec extends SpecBase {
     val deskProLinkText = "Is this page not working properly? (opens in new tab)"
     val cdsSubscribeUrl = "https://www.tax.service.gov.uk/customs-enrolment-services/cds/subscribe"
 
-    val app: Application = buildApp
-
-    implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
-    implicit val msg: Messages = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
-    val view: Document = Jsoup.parse(
-      app.injector.instanceOf[unauthorised].apply().body)
+    val view: Document = Jsoup.parse(buildApp.injector.instanceOf[unauthorised].apply().body)
   }
 }

--- a/test/views/ViewTestHelper.scala
+++ b/test/views/ViewTestHelper.scala
@@ -28,7 +28,6 @@ import utils.SpecBase
 trait ViewTestHelper extends SpecBase {
 
   implicit lazy val app: Application = buildApp
-  implicit val messages: Messages = messages(app)
   implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest()
 
   def titleShouldBeCorrect(view: Document,

--- a/test/views/ViewTestHelper.scala
+++ b/test/views/ViewTestHelper.scala
@@ -16,11 +16,9 @@
 
 package views
 
-import config.AppConfig
 import org.jsoup.nodes.Document
 import org.scalatest.Assertion
 import play.api.Application
-import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import utils.SpecBase

--- a/test/views/ViewTestHelper.scala
+++ b/test/views/ViewTestHelper.scala
@@ -25,7 +25,7 @@ import utils.SpecBase
 
 trait ViewTestHelper extends SpecBase {
 
-  implicit lazy val app: Application = buildApp
+  implicit lazy val app: Application = application
   implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest()
 
   def titleShouldBeCorrect(view: Document,

--- a/test/views/ViewTestHelper.scala
+++ b/test/views/ViewTestHelper.scala
@@ -27,9 +27,8 @@ import utils.SpecBase
 
 trait ViewTestHelper extends SpecBase {
 
-  implicit lazy val app: Application = application.build()
+  implicit lazy val app: Application = buildApp
   implicit val messages: Messages = messages(app)
-  implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
   implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest()
 
   def titleShouldBeCorrect(view: Document,

--- a/test/views/components/ButtonSpec.scala
+++ b/test/views/components/ButtonSpec.scala
@@ -48,7 +48,7 @@ class ButtonSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = buildApp
+    val app: Application = application
     val msgKey: String = "cf.verify.your.email.change.button"
     val hrefValue = "www.test.com"
     val classesValue = "govuk-!-margin-bottom-7"

--- a/test/views/components/ButtonSpec.scala
+++ b/test/views/components/ButtonSpec.scala
@@ -18,7 +18,6 @@ package views.components
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.Application
 import utils.SpecBase
 import views.html.components.button
 

--- a/test/views/components/ButtonSpec.scala
+++ b/test/views/components/ButtonSpec.scala
@@ -19,7 +19,6 @@ package views.components
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.Application
-import play.api.i18n.Messages
 import utils.SpecBase
 import views.html.components.button
 

--- a/test/views/components/ButtonSpec.scala
+++ b/test/views/components/ButtonSpec.scala
@@ -49,7 +49,7 @@ class ButtonSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
+    val app: Application = buildApp
     val msgKey: String = "cf.verify.your.email.change.button"
     val hrefValue = "www.test.com"
     val classesValue = "govuk-!-margin-bottom-7"

--- a/test/views/components/ButtonSpec.scala
+++ b/test/views/components/ButtonSpec.scala
@@ -32,7 +32,7 @@ class ButtonSpec extends SpecBase {
       "it contains msg, href and classes value" in new Setup {
         private val btnComponentAsText = buttonComponent.text()
 
-        btnComponentAsText.contains(messages(app)(msgKey)) mustBe true
+        btnComponentAsText.contains(messages(msgKey)) mustBe true
         buttonComponent.html().contains(hrefValue) mustBe true
 
         buttonComponent.getElementsByClass(classesValue).size() mustBe 1
@@ -41,7 +41,7 @@ class ButtonSpec extends SpecBase {
       "it does not contain href and classes" in new Setup {
         private val buttonComponentWithNoHrefAsText = buttonComponentWithNoHref.text()
 
-        buttonComponentWithNoHrefAsText.contains(messages(app)(msgKey)) mustBe true
+        buttonComponentWithNoHrefAsText.contains(messages(msgKey)) mustBe true
         buttonComponentWithNoHref.html().contains(hrefValue) mustBe false
         buttonComponentWithNoHref.html().contains(classesValue) mustBe false
       }
@@ -53,8 +53,6 @@ class ButtonSpec extends SpecBase {
     val msgKey: String = "cf.verify.your.email.change.button"
     val hrefValue = "www.test.com"
     val classesValue = "govuk-!-margin-bottom-7"
-
-    implicit val msg: Messages = messages(app)
 
     val buttonComponent: Document =
       Jsoup.parse(app.injector.instanceOf[button].apply(msgKey, Some(hrefValue), classesValue).body)

--- a/test/views/components/ButtonSpec.scala
+++ b/test/views/components/ButtonSpec.scala
@@ -48,15 +48,14 @@ class ButtonSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application
     val msgKey: String = "cf.verify.your.email.change.button"
     val hrefValue = "www.test.com"
     val classesValue = "govuk-!-margin-bottom-7"
 
     val buttonComponent: Document =
-      Jsoup.parse(app.injector.instanceOf[button].apply(msgKey, Some(hrefValue), classesValue).body)
+      Jsoup.parse(application.injector.instanceOf[button].apply(msgKey, Some(hrefValue), classesValue).body)
 
     val buttonComponentWithNoHref: Document =
-      Jsoup.parse(app.injector.instanceOf[button].apply(msgKey).body)
+      Jsoup.parse(application.injector.instanceOf[button].apply(msgKey).body)
   }
 }

--- a/test/views/components/CashAccountBalanceSpec.scala
+++ b/test/views/components/CashAccountBalanceSpec.scala
@@ -158,8 +158,6 @@ class CashAccountBalanceSpec extends SpecBase {
 
   trait Setup {
     val app: Application = buildApp
-    implicit val config: AppConfig = app.injector.instanceOf[AppConfig]
-    implicit val msgs: Messages = messages(app)
 
     val eori: String = "test_eori"
     val accountBalance: Int = 6000

--- a/test/views/components/CashAccountBalanceSpec.scala
+++ b/test/views/components/CashAccountBalanceSpec.scala
@@ -16,7 +16,6 @@
 
 package views.components
 
-import config.AppConfig
 import helpers.Formatters.formatCurrencyAmount
 import models.{AccountStatusOpen, CDSCashBalance, CashAccount, CashAccountViewModel}
 import org.jsoup.Jsoup

--- a/test/views/components/CashAccountBalanceSpec.scala
+++ b/test/views/components/CashAccountBalanceSpec.scala
@@ -156,7 +156,7 @@ class CashAccountBalanceSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = buildApp
+    val app: Application = application
 
     val eori: String = "test_eori"
     val accountBalance: Int = 6000

--- a/test/views/components/CashAccountBalanceSpec.scala
+++ b/test/views/components/CashAccountBalanceSpec.scala
@@ -157,7 +157,7 @@ class CashAccountBalanceSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val config: AppConfig = app.injector.instanceOf[AppConfig]
     implicit val msgs: Messages = messages(app)
 

--- a/test/views/components/CashAccountBalanceSpec.scala
+++ b/test/views/components/CashAccountBalanceSpec.scala
@@ -21,7 +21,6 @@ import models.{AccountStatusOpen, CDSCashBalance, CashAccount, CashAccountViewMo
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.Assertion
-import play.api.Application
 import play.api.i18n.Messages
 import utils.SpecBase
 import views.html.components.cash_account_balance
@@ -156,8 +155,6 @@ class CashAccountBalanceSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application
-
     val eori: String = "test_eori"
     val accountBalance: Int = 6000
     val balances: CDSCashBalance = CDSCashBalance(None)
@@ -166,7 +163,7 @@ class CashAccountBalanceSpec extends SpecBase {
     def view(accountModel: CashAccountViewModel,
              showBalance: Boolean = true,
              displayLastSixMonthsHeading: Boolean = true): Document =
-      Jsoup.parse(app.injector.instanceOf[cash_account_balance]
+      Jsoup.parse(application.injector.instanceOf[cash_account_balance]
         .apply(accountModel, showBalance, displayLastSixMonthsHeading).body)
   }
 }

--- a/test/views/components/ErrorSummarySpec.scala
+++ b/test/views/components/ErrorSummarySpec.scala
@@ -46,7 +46,7 @@ class ErrorSummarySpec extends SpecBase {
 
       when(mockGovSummary.apply(any[ErrorSummary])).thenReturn(govSummaryHtmlFormat)
 
-      val app: Application = application.overrides(
+      val app: Application = applicationBuilder.overrides(
         inject.bind[GovukErrorSummary].toInstance(mockGovSummary)
       ).build()
 
@@ -72,7 +72,7 @@ class ErrorSummarySpec extends SpecBase {
 
       when(mockGovSummary.apply(any[ErrorSummary])).thenReturn(govSummaryHtmlFormat)
 
-      val app: Application = application.overrides(
+      val app: Application = applicationBuilder.overrides(
         inject.bind[GovukErrorSummary].toInstance(mockGovSummary)
       ).build()
 
@@ -102,7 +102,7 @@ class ErrorSummarySpec extends SpecBase {
 
       when(mockGovSummary.apply(any[ErrorSummary])).thenReturn(govSummaryHtmlFormat)
 
-      val app: Application = application.overrides(
+      val app: Application = applicationBuilder.overrides(
         inject.bind[GovukErrorSummary].toInstance(mockGovSummary)
       ).build()
 
@@ -132,7 +132,7 @@ class ErrorSummarySpec extends SpecBase {
 
       when(mockGovSummary.apply(any[ErrorSummary])).thenReturn(govSummaryHtmlFormat)
 
-      val app: Application = application.overrides(
+      val app: Application = applicationBuilder.overrides(
         inject.bind[GovukErrorSummary].toInstance(mockGovSummary)
       ).build()
 
@@ -162,7 +162,7 @@ class ErrorSummarySpec extends SpecBase {
 
       when(mockGovSummary.apply(any[ErrorSummary])).thenReturn(govSummaryHtmlFormat)
 
-      val app: Application = application.overrides(
+      val app: Application = applicationBuilder.overrides(
         inject.bind[GovukErrorSummary].toInstance(mockGovSummary)
       ).build()
 

--- a/test/views/components/H1InnerSpec.scala
+++ b/test/views/components/H1InnerSpec.scala
@@ -77,7 +77,7 @@ class H1InnerSpec extends SpecBase {
 
   trait Setup {
 
-    val app: Application = application.build()
+    val app: Application = buildApp
     val msgKey: String = "cf.message"
     val innerMsgKey: String = "cf.message.inner"
     val idValue: Option[String] = Some("test-id")

--- a/test/views/components/H1InnerSpec.scala
+++ b/test/views/components/H1InnerSpec.scala
@@ -18,7 +18,6 @@ package views.components
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.Application
 import utils.SpecBase
 import views.html.components.h1Inner
 
@@ -76,25 +75,24 @@ class H1InnerSpec extends SpecBase {
 
   trait Setup {
 
-    val app: Application = application
     val msgKey: String = "cf.message"
     val innerMsgKey: String = "cf.message.inner"
     val idValue: Option[String] = Some("test-id")
     val classesValue: String = "govuk-heading-xl"
 
     val h1InnerComponent: Document =
-      Jsoup.parse(app.injector.instanceOf[h1Inner].apply(msgKey, innerMsgKey, idValue, classesValue).body)
+      Jsoup.parse(application.injector.instanceOf[h1Inner].apply(msgKey, innerMsgKey, idValue, classesValue).body)
 
     val h1InnerComponentWithNoId: Document =
-      Jsoup.parse(app.injector.instanceOf[h1Inner].apply(msgKey, innerMsgKey, None, classesValue).body)
+      Jsoup.parse(application.injector.instanceOf[h1Inner].apply(msgKey, innerMsgKey, None, classesValue).body)
 
     val h1InnerComponentWithDefaultClass: Document =
-      Jsoup.parse(app.injector.instanceOf[h1Inner].apply(msgKey, innerMsgKey, idValue).body)
+      Jsoup.parse(application.injector.instanceOf[h1Inner].apply(msgKey, innerMsgKey, idValue).body)
 
     val h1InnerComponentWithEmptyInnerMsg: Document =
-      Jsoup.parse(app.injector.instanceOf[h1Inner].apply(msgKey, emptyString, None, classesValue).body)
+      Jsoup.parse(application.injector.instanceOf[h1Inner].apply(msgKey, emptyString, None, classesValue).body)
 
     val h1InnerComponentWithEmptyClass: Document =
-      Jsoup.parse(app.injector.instanceOf[h1Inner].apply(msgKey, innerMsgKey, idValue, emptyString).body)
+      Jsoup.parse(application.injector.instanceOf[h1Inner].apply(msgKey, innerMsgKey, idValue, emptyString).body)
   }
 }

--- a/test/views/components/H1InnerSpec.scala
+++ b/test/views/components/H1InnerSpec.scala
@@ -76,7 +76,7 @@ class H1InnerSpec extends SpecBase {
 
   trait Setup {
 
-    val app: Application = buildApp
+    val app: Application = application
     val msgKey: String = "cf.message"
     val innerMsgKey: String = "cf.message.inner"
     val idValue: Option[String] = Some("test-id")

--- a/test/views/components/H1InnerSpec.scala
+++ b/test/views/components/H1InnerSpec.scala
@@ -33,7 +33,7 @@ class H1InnerSpec extends SpecBase {
 
         private val h1InnerComponentAsText = h1InnerComponent.text()
 
-        h1InnerComponentAsText mustBe messages(app)(msgKey, messages(app)(innerMsgKey))
+        h1InnerComponentAsText mustBe messages(msgKey, messages(innerMsgKey))
         h1InnerComponent.select("h1").attr("class") mustBe classesValue
         h1InnerComponent.select("h1").attr("id") mustBe idValue.get
       }
@@ -42,7 +42,7 @@ class H1InnerSpec extends SpecBase {
 
         private val h1InnerComponentWithNoIdAsText = h1InnerComponentWithNoId.text()
 
-        h1InnerComponentWithNoIdAsText mustBe messages(app)(msgKey, messages(app)(innerMsgKey))
+        h1InnerComponentWithNoIdAsText mustBe messages(msgKey, messages(innerMsgKey))
         h1InnerComponentWithNoId.select("h1").attr("class") mustBe classesValue
         h1InnerComponentWithNoId.select("h1").hasAttr("id") mustBe false
       }
@@ -51,7 +51,7 @@ class H1InnerSpec extends SpecBase {
 
         private val h1InnerComponentWithDefaultClassAsText = h1InnerComponentWithDefaultClass.text()
 
-        h1InnerComponentWithDefaultClassAsText mustBe messages(app)(msgKey, messages(app)(innerMsgKey))
+        h1InnerComponentWithDefaultClassAsText mustBe messages(msgKey, messages(innerMsgKey))
         h1InnerComponentWithDefaultClass.select("h1").attr("class") mustBe "govuk-heading-xl"
       }
 
@@ -59,7 +59,7 @@ class H1InnerSpec extends SpecBase {
 
         private val h1InnerComponentWithEmptyInnerMsgAsText = h1InnerComponentWithEmptyInnerMsg.text()
 
-        h1InnerComponentWithEmptyInnerMsgAsText mustBe messages(app)(msgKey, emptyString)
+        h1InnerComponentWithEmptyInnerMsgAsText mustBe messages(msgKey, emptyString)
         h1InnerComponentWithEmptyInnerMsg.select("h1").attr("class") mustBe classesValue
         h1InnerComponentWithEmptyInnerMsg.select("h1").hasAttr("id") mustBe false
       }
@@ -68,7 +68,7 @@ class H1InnerSpec extends SpecBase {
 
         private val h1InnerComponentWithEmptyClassAsText = h1InnerComponentWithEmptyClass.text()
 
-        h1InnerComponentWithEmptyClassAsText mustBe messages(app)(msgKey, messages(app)(innerMsgKey))
+        h1InnerComponentWithEmptyClassAsText mustBe messages(msgKey, messages(innerMsgKey))
         h1InnerComponentWithEmptyClass.select("h1").attr("class") mustBe emptyString
         h1InnerComponentWithEmptyClass.select("h1").attr("id") mustBe idValue.get
       }
@@ -82,8 +82,6 @@ class H1InnerSpec extends SpecBase {
     val innerMsgKey: String = "cf.message.inner"
     val idValue: Option[String] = Some("test-id")
     val classesValue: String = "govuk-heading-xl"
-
-    implicit val msg: Messages = messages(app)
 
     val h1InnerComponent: Document =
       Jsoup.parse(app.injector.instanceOf[h1Inner].apply(msgKey, innerMsgKey, idValue, classesValue).body)

--- a/test/views/components/H1InnerSpec.scala
+++ b/test/views/components/H1InnerSpec.scala
@@ -19,7 +19,6 @@ package views.components
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.Application
-import play.api.i18n.Messages
 import utils.SpecBase
 import views.html.components.h1Inner
 

--- a/test/views/components/H2InnerSpec.scala
+++ b/test/views/components/H2InnerSpec.scala
@@ -18,7 +18,6 @@ package views.components
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.Application
 import utils.SpecBase
 import views.html.components.h2Inner
 
@@ -76,25 +75,24 @@ class H2InnerSpec extends SpecBase {
 
   trait Setup {
 
-    val app: Application = application
     val msgKey: String = "cf.message"
     val innerMsgKey: String = "cf.message.inner"
     val idValue: Option[String] = Some("test-id")
     val classesValue: String = "govuk-heading-m"
 
     val h2InnerComponent: Document =
-      Jsoup.parse(app.injector.instanceOf[h2Inner].apply(msgKey, innerMsgKey, idValue, classesValue).body)
+      Jsoup.parse(application.injector.instanceOf[h2Inner].apply(msgKey, innerMsgKey, idValue, classesValue).body)
 
     val h2InnerComponentWithNoId: Document =
-      Jsoup.parse(app.injector.instanceOf[h2Inner].apply(msgKey, innerMsgKey, None, classesValue).body)
+      Jsoup.parse(application.injector.instanceOf[h2Inner].apply(msgKey, innerMsgKey, None, classesValue).body)
 
     val h2InnerComponentWithDefaultClass: Document =
-      Jsoup.parse(app.injector.instanceOf[h2Inner].apply(msgKey, innerMsgKey, idValue).body)
+      Jsoup.parse(application.injector.instanceOf[h2Inner].apply(msgKey, innerMsgKey, idValue).body)
 
     val h2InnerComponentWithEmptyInnerMsg: Document =
-      Jsoup.parse(app.injector.instanceOf[h2Inner].apply(msgKey, emptyString, None, classesValue).body)
+      Jsoup.parse(application.injector.instanceOf[h2Inner].apply(msgKey, emptyString, None, classesValue).body)
 
     val h2InnerComponentWithEmptyClass: Document =
-      Jsoup.parse(app.injector.instanceOf[h2Inner].apply(msgKey, innerMsgKey, idValue, emptyString).body)
+      Jsoup.parse(application.injector.instanceOf[h2Inner].apply(msgKey, innerMsgKey, idValue, emptyString).body)
   }
 }

--- a/test/views/components/H2InnerSpec.scala
+++ b/test/views/components/H2InnerSpec.scala
@@ -19,7 +19,6 @@ package views.components
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.Application
-import play.api.i18n.Messages
 import utils.SpecBase
 import views.html.components.h2Inner
 

--- a/test/views/components/H2InnerSpec.scala
+++ b/test/views/components/H2InnerSpec.scala
@@ -33,7 +33,7 @@ class H2InnerSpec extends SpecBase {
 
         private val h2InnerComponentAsText = h2InnerComponent.text()
 
-        h2InnerComponentAsText mustBe messages(app)(msgKey, messages(app)(innerMsgKey))
+        h2InnerComponentAsText mustBe messages(msgKey, messages(innerMsgKey))
         h2InnerComponent.select("h2").attr("class") mustBe classesValue
         h2InnerComponent.select("h2").attr("id") mustBe idValue.get
       }
@@ -42,7 +42,7 @@ class H2InnerSpec extends SpecBase {
 
         private val h2InnerComponentWithNoIdAsText = h2InnerComponentWithNoId.text()
 
-        h2InnerComponentWithNoIdAsText mustBe messages(app)(msgKey, messages(app)(innerMsgKey))
+        h2InnerComponentWithNoIdAsText mustBe messages(msgKey, messages(innerMsgKey))
         h2InnerComponentWithNoId.select("h2").attr("class") mustBe classesValue
         h2InnerComponentWithNoId.select("h2").hasAttr("id") mustBe false
       }
@@ -51,7 +51,7 @@ class H2InnerSpec extends SpecBase {
 
         private val h2InnerComponentWithDefaultClassAsText = h2InnerComponentWithDefaultClass.text()
 
-        h2InnerComponentWithDefaultClassAsText mustBe messages(app)(msgKey, messages(app)(innerMsgKey))
+        h2InnerComponentWithDefaultClassAsText mustBe messages(msgKey, messages(innerMsgKey))
         h2InnerComponentWithDefaultClass.select("h2").attr("class") mustBe "govuk-heading-m"
       }
 
@@ -59,7 +59,7 @@ class H2InnerSpec extends SpecBase {
 
         private val h2InnerComponentWithEmptyInnerMsgAsText = h2InnerComponentWithEmptyInnerMsg.text()
 
-        h2InnerComponentWithEmptyInnerMsgAsText mustBe messages(app)(msgKey, emptyString)
+        h2InnerComponentWithEmptyInnerMsgAsText mustBe messages(msgKey, emptyString)
         h2InnerComponentWithEmptyInnerMsg.select("h2").attr("class") mustBe classesValue
         h2InnerComponentWithEmptyInnerMsg.select("h2").hasAttr("id") mustBe false
       }
@@ -68,7 +68,7 @@ class H2InnerSpec extends SpecBase {
 
         private val h2InnerComponentWithEmptyClassAsText = h2InnerComponentWithEmptyClass.text()
 
-        h2InnerComponentWithEmptyClassAsText mustBe messages(app)(msgKey, messages(app)(innerMsgKey))
+        h2InnerComponentWithEmptyClassAsText mustBe messages(msgKey, messages(innerMsgKey))
         h2InnerComponentWithEmptyClass.select("h2").attr("class") mustBe emptyString
         h2InnerComponentWithEmptyClass.select("h2").attr("id") mustBe idValue.get
       }
@@ -82,8 +82,6 @@ class H2InnerSpec extends SpecBase {
     val innerMsgKey: String = "cf.message.inner"
     val idValue: Option[String] = Some("test-id")
     val classesValue: String = "govuk-heading-m"
-
-    implicit val msg: Messages = messages(app)
 
     val h2InnerComponent: Document =
       Jsoup.parse(app.injector.instanceOf[h2Inner].apply(msgKey, innerMsgKey, idValue, classesValue).body)

--- a/test/views/components/H2InnerSpec.scala
+++ b/test/views/components/H2InnerSpec.scala
@@ -77,7 +77,7 @@ class H2InnerSpec extends SpecBase {
 
   trait Setup {
 
-    val app: Application = application.build()
+    val app: Application = buildApp
     val msgKey: String = "cf.message"
     val innerMsgKey: String = "cf.message.inner"
     val idValue: Option[String] = Some("test-id")

--- a/test/views/components/H2InnerSpec.scala
+++ b/test/views/components/H2InnerSpec.scala
@@ -76,7 +76,7 @@ class H2InnerSpec extends SpecBase {
 
   trait Setup {
 
-    val app: Application = buildApp
+    val app: Application = application
     val msgKey: String = "cf.message"
     val innerMsgKey: String = "cf.message.inner"
     val idValue: Option[String] = Some("test-id")

--- a/test/views/components/H2Spec.scala
+++ b/test/views/components/H2Spec.scala
@@ -18,7 +18,6 @@ package views.components
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.Application
 import utils.SpecBase
 import views.html.components.h2
 
@@ -40,7 +39,6 @@ class H2Spec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application
 
     val msg: String = "some message"
     val id: String = "test_id"
@@ -49,9 +47,9 @@ class H2Spec extends SpecBase {
     val extraContent: String = "some extra content"
 
     val h2Component: Document =
-      Jsoup.parse(app.injector.instanceOf[h2].apply(msg, Some(id), classes, Some(extraContent)).body)
+      Jsoup.parse(application.injector.instanceOf[h2].apply(msg, Some(id), classes, Some(extraContent)).body)
 
     val h2ComponentWithoutContent: Document =
-      Jsoup.parse(app.injector.instanceOf[h2].apply(msg, Some(idNoContent), classes).body)
+      Jsoup.parse(application.injector.instanceOf[h2].apply(msg, Some(idNoContent), classes).body)
   }
 }

--- a/test/views/components/H2Spec.scala
+++ b/test/views/components/H2Spec.scala
@@ -40,7 +40,7 @@ class H2Spec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = buildApp
+    val app: Application = application
 
     val msg: String = "some message"
     val id: String = "test_id"

--- a/test/views/components/H2Spec.scala
+++ b/test/views/components/H2Spec.scala
@@ -41,7 +41,7 @@ class H2Spec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val msgs: Messages = messages(app)
 
     val msg: String = "some message"

--- a/test/views/components/H2Spec.scala
+++ b/test/views/components/H2Spec.scala
@@ -42,7 +42,6 @@ class H2Spec extends SpecBase {
 
   trait Setup {
     val app: Application = buildApp
-    implicit val msgs: Messages = messages(app)
 
     val msg: String = "some message"
     val id: String = "test_id"

--- a/test/views/components/H2Spec.scala
+++ b/test/views/components/H2Spec.scala
@@ -19,7 +19,6 @@ package views.components
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.Application
-import play.api.i18n.Messages
 import utils.SpecBase
 import views.html.components.h2
 

--- a/test/views/components/InputDateSpec.scala
+++ b/test/views/components/InputDateSpec.scala
@@ -202,7 +202,7 @@ class InputDateSpec extends SpecBase {
       val id = "value"
       val headline = "Date of birth"
 
-      val app: Application = buildApp
+      val app: Application = application
     }
   }
 }

--- a/test/views/components/InputDateSpec.scala
+++ b/test/views/components/InputDateSpec.scala
@@ -17,10 +17,11 @@
 package views.components
 
 import forms.CashTransactionsRequestPageFormProvider
-import play.api.Application
+import models.CashTransactionDates
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.test.Helpers._
+import play.api.data.Form
+import play.api.test.Helpers.*
 import play.twirl.api.HtmlFormat
 import utils.SpecBase
 import views.html.components.inputDate
@@ -33,7 +34,7 @@ class InputDateSpec extends SpecBase {
 
     "render correctly with no errors" in new Setup {
 
-      val formWithValues = form.bind(
+      val formWithValues: Form[CashTransactionDates] = form.bind(
         Map(
           s"$id.day" -> "01",
           s"$id.month" -> "01",
@@ -41,8 +42,8 @@ class InputDateSpec extends SpecBase {
         )
       )
 
-      running(app) {
-        val inputDateView = app.injector.instanceOf[inputDate]
+      running(application) {
+        val inputDateView = application.injector.instanceOf[inputDate]
 
         val output: HtmlFormat.Appendable = inputDateView(
           formWithValues,
@@ -66,7 +67,7 @@ class InputDateSpec extends SpecBase {
 
     "render h1 tag correctly" in new Setup {
 
-      val formWithValues = form.bind(
+      val formWithValues: Form[CashTransactionDates] = form.bind(
         Map(
           s"$id.day" -> "01",
           s"$id.month" -> "01",
@@ -74,8 +75,8 @@ class InputDateSpec extends SpecBase {
         )
       )
 
-      running(app) {
-        val inputDateView = app.injector.instanceOf[inputDate]
+      running(application) {
+        val inputDateView = application.injector.instanceOf[inputDate]
 
         val output: HtmlFormat.Appendable = inputDateView(
           formWithValues,
@@ -107,8 +108,8 @@ class InputDateSpec extends SpecBase {
         )
       )
 
-      running(app) {
-        val inputDateView = app.injector.instanceOf[inputDate]
+      running(application) {
+        val inputDateView = application.injector.instanceOf[inputDate]
 
         val output: HtmlFormat.Appendable = inputDateView(
           formWithValues,
@@ -132,7 +133,7 @@ class InputDateSpec extends SpecBase {
 
     "render correctly with year error" in new Setup {
 
-      val formWithValues = form.bind(
+      val formWithValues: Form[CashTransactionDates] = form.bind(
         Map(
           s"$id.day" -> "01",
           s"$id.month" -> "01",
@@ -140,8 +141,8 @@ class InputDateSpec extends SpecBase {
         )
       )
 
-      running(app) {
-        val inputDateView = app.injector.instanceOf[inputDate]
+      running(application) {
+        val inputDateView = application.injector.instanceOf[inputDate]
 
         val output: HtmlFormat.Appendable = inputDateView(
           formWithValues,
@@ -165,7 +166,7 @@ class InputDateSpec extends SpecBase {
 
     "render correctly with both day, month and year errors" in new Setup {
 
-      val formWithValues = form.bind(
+      val formWithValues: Form[CashTransactionDates] = form.bind(
         Map(
           s"$id.day" -> "",
           s"$id.month" -> "",
@@ -173,8 +174,8 @@ class InputDateSpec extends SpecBase {
         )
       )
 
-      running(app) {
-        val inputDateView = app.injector.instanceOf[inputDate]
+      running(application) {
+        val inputDateView = application.injector.instanceOf[inputDate]
 
         val output: HtmlFormat.Appendable = inputDateView(
           formWithValues,
@@ -198,11 +199,10 @@ class InputDateSpec extends SpecBase {
 
     trait Setup {
       implicit val clk: Clock = Clock.systemUTC()
-      val form = new CashTransactionsRequestPageFormProvider().apply()
+
+      val form: Form[CashTransactionDates] = new CashTransactionsRequestPageFormProvider().apply()
       val id = "value"
       val headline = "Date of birth"
-
-      val app: Application = application
     }
   }
 }

--- a/test/views/components/InputDateSpec.scala
+++ b/test/views/components/InputDateSpec.scala
@@ -52,7 +52,7 @@ class InputDateSpec extends SpecBase {
           legendClasses = "legend-class",
           hintText = None,
           legendAsPageHeading = false
-        )(messages(app))
+        )(messages)
 
         val html: Document = Jsoup.parse(output.toString)
 
@@ -85,7 +85,7 @@ class InputDateSpec extends SpecBase {
           legendClasses = "legend-class",
           hintText = None,
           legendAsPageHeading = true
-        )(messages(app))
+        )(messages)
 
         val html: Document = Jsoup.parse(output.toString)
 
@@ -118,7 +118,7 @@ class InputDateSpec extends SpecBase {
           legendClasses = "legend-class",
           hintText = None,
           legendAsPageHeading = false
-        )(messages(app))
+        )(messages)
 
         val html: Document = Jsoup.parse(output.toString)
 
@@ -151,7 +151,7 @@ class InputDateSpec extends SpecBase {
           legendClasses = "legend-class",
           hintText = None,
           legendAsPageHeading = false
-        )(messages(app))
+        )(messages)
 
         val html: Document = Jsoup.parse(output.toString)
 
@@ -184,7 +184,7 @@ class InputDateSpec extends SpecBase {
           legendClasses = "legend-class",
           hintText = None,
           legendAsPageHeading = false
-        )(messages(app))
+        )(messages)
 
         val html: Document = Jsoup.parse(output.toString)
 

--- a/test/views/components/InputDateSpec.scala
+++ b/test/views/components/InputDateSpec.scala
@@ -202,7 +202,7 @@ class InputDateSpec extends SpecBase {
       val id = "value"
       val headline = "Date of birth"
 
-      val app: Application = application.build()
+      val app: Application = buildApp
     }
   }
 }

--- a/test/views/components/InputTextSpec.scala
+++ b/test/views/components/InputTextSpec.scala
@@ -102,7 +102,7 @@ class InputTextSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val msg: Messages = messages(app)
 
     val validForm: Form[String] = new SearchTransactionsFormProvider().apply().bind(Map("value" -> "GB123456789012"))

--- a/test/views/components/InputTextSpec.scala
+++ b/test/views/components/InputTextSpec.scala
@@ -44,7 +44,7 @@ class InputTextSpec extends SpecBase {
         hint = None
       ).body)
 
-      view.getElementsByTag("label").html() mustBe messages(app)("eoriNumber.heading")
+      view.getElementsByTag("label").html() mustBe messages("eoriNumber.heading")
       view.getElementById("value").`val`() mustBe "GB123456789012"
 
       intercept[RuntimeException] {
@@ -103,7 +103,6 @@ class InputTextSpec extends SpecBase {
 
   trait Setup {
     val app: Application = buildApp
-    implicit val msg: Messages = messages(app)
 
     val validForm: Form[String] = new SearchTransactionsFormProvider().apply().bind(Map("value" -> "GB123456789012"))
     val invalidForm: Form[String] = new SearchTransactionsFormProvider().apply().bind(Map("value" -> emptyString))

--- a/test/views/components/InputTextSpec.scala
+++ b/test/views/components/InputTextSpec.scala
@@ -101,7 +101,7 @@ class InputTextSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = buildApp
+    val app: Application = application
 
     val validForm: Form[String] = new SearchTransactionsFormProvider().apply().bind(Map("value" -> "GB123456789012"))
     val invalidForm: Form[String] = new SearchTransactionsFormProvider().apply().bind(Map("value" -> emptyString))

--- a/test/views/components/InputTextSpec.scala
+++ b/test/views/components/InputTextSpec.scala
@@ -20,7 +20,6 @@ import forms.SearchTransactionsFormProvider
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
-import play.api.Application
 import play.api.data.Form
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.FormGroup
@@ -34,7 +33,7 @@ class InputTextSpec extends SpecBase {
 
   "InputText" should {
     "display the correct view" in new Setup {
-      val view: Document = Jsoup.parse(app.injector.instanceOf[inputText].apply(
+      val view: Document = Jsoup.parse(application.injector.instanceOf[inputText].apply(
         form = validForm,
         id = "value",
         name = "value",
@@ -52,7 +51,7 @@ class InputTextSpec extends SpecBase {
     }
 
     "display the correct hint" in new Setup {
-      val view: Document = Jsoup.parse(app.injector.instanceOf[inputText].apply(
+      val view: Document = Jsoup.parse(application.injector.instanceOf[inputText].apply(
         form = validForm,
         id = "value",
         name = "value",
@@ -70,7 +69,7 @@ class InputTextSpec extends SpecBase {
     "display the inline component if any component is passed as part of FormGroup" in new Setup {
       val button: HtmlFormat.Appendable = new button(new GovukButton()).apply(msg = buttonText)
 
-      val view: Document = Jsoup.parse(app.injector.instanceOf[inputText].apply(
+      val view: Document = Jsoup.parse(application.injector.instanceOf[inputText].apply(
         form = invalidForm,
         id = "value",
         name = "value",
@@ -86,7 +85,7 @@ class InputTextSpec extends SpecBase {
     }
 
     "display error if form has any error" in new Setup {
-      val view: Document = Jsoup.parse(app.injector.instanceOf[inputText].apply(
+      val view: Document = Jsoup.parse(application.injector.instanceOf[inputText].apply(
         form = invalidForm,
         id = "value",
         name = "value",
@@ -101,8 +100,6 @@ class InputTextSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application
-
     val validForm: Form[String] = new SearchTransactionsFormProvider().apply().bind(Map("value" -> "GB123456789012"))
     val invalidForm: Form[String] = new SearchTransactionsFormProvider().apply().bind(Map("value" -> emptyString))
 

--- a/test/views/components/InputTextSpec.scala
+++ b/test/views/components/InputTextSpec.scala
@@ -22,7 +22,6 @@ import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
 import play.api.Application
 import play.api.data.Form
-import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.FormGroup
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent

--- a/test/views/components/LinkSpec.scala
+++ b/test/views/components/LinkSpec.scala
@@ -16,7 +16,6 @@
 
 package views.components
 
-import play.api.Application
 import views.html.components.link
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -58,23 +57,21 @@ class LinkSpec extends SpecBase {
     val testPreLinkMsg = "preLink_message"
     val testPostLinkMsg = "postLink_message"
 
-    val app: Application = application
-
     val linkComponent: Document =
-      Jsoup.parse(app.injector.instanceOf[link].apply(linkMessageKey, location, Some(linkId)).body)
+      Jsoup.parse(application.injector.instanceOf[link].apply(linkMessageKey, location, Some(linkId)).body)
 
     val linkComponentWithPId: Document =
-      Jsoup.parse(app.injector.instanceOf[link].apply(
+      Jsoup.parse(application.injector.instanceOf[link].apply(
         linkMessageKey = linkMessageKey, location = location, pId = Some(pId)).body)
 
-    val linkComponentWithPreAndPostLinkMsg: Document = Jsoup.parse(app.injector.instanceOf[link].apply(
+    val linkComponentWithPreAndPostLinkMsg: Document = Jsoup.parse(application.injector.instanceOf[link].apply(
       linkMessageKey = linkMessageKey,
       location = location,
       pId = Some(pId),
       preLinkMessage = Some(testPreLinkMsg),
       postLinkMessage = Some(testPostLinkMsg)).body)
 
-    val linkComponentWithLinkMessage: Document = Jsoup.parse(app.injector.instanceOf[link].apply(
+    val linkComponentWithLinkMessage: Document = Jsoup.parse(application.injector.instanceOf[link].apply(
       linkMessageKey = linkMessageKey,
       location = location,
       linkId = Some(linkId),

--- a/test/views/components/LinkSpec.scala
+++ b/test/views/components/LinkSpec.scala
@@ -61,8 +61,6 @@ class LinkSpec extends SpecBase {
 
     val app: Application = buildApp
 
-    implicit val msgs: Messages = messages(app)
-
     val linkComponent: Document =
       Jsoup.parse(app.injector.instanceOf[link].apply(linkMessageKey, location, Some(linkId)).body)
 

--- a/test/views/components/LinkSpec.scala
+++ b/test/views/components/LinkSpec.scala
@@ -59,7 +59,7 @@ class LinkSpec extends SpecBase {
     val testPreLinkMsg = "preLink_message"
     val testPostLinkMsg = "postLink_message"
 
-    val app: Application = application.build()
+    val app: Application = buildApp
 
     implicit val msgs: Messages = messages(app)
 

--- a/test/views/components/LinkSpec.scala
+++ b/test/views/components/LinkSpec.scala
@@ -58,7 +58,7 @@ class LinkSpec extends SpecBase {
     val testPreLinkMsg = "preLink_message"
     val testPostLinkMsg = "postLink_message"
 
-    val app: Application = buildApp
+    val app: Application = application
 
     val linkComponent: Document =
       Jsoup.parse(app.injector.instanceOf[link].apply(linkMessageKey, location, Some(linkId)).body)

--- a/test/views/components/LinkSpec.scala
+++ b/test/views/components/LinkSpec.scala
@@ -20,7 +20,6 @@ import play.api.Application
 import views.html.components.link
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.i18n.Messages
 import utils.SpecBase
 
 class LinkSpec extends SpecBase {

--- a/test/views/components/NewTabLinkSpec.scala
+++ b/test/views/components/NewTabLinkSpec.scala
@@ -98,7 +98,7 @@ class NewTabLinkSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
+    val app: Application = buildApp
 
     val linkMessage: String = "go to test page"
     val href = "www.test.com"

--- a/test/views/components/NewTabLinkSpec.scala
+++ b/test/views/components/NewTabLinkSpec.scala
@@ -16,13 +16,10 @@
 
 package views.components
 
-import config.AppConfig
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.Assertion
-import play.api.Application
-import play.api.i18n.Messages
 import utils.SpecBase
 import utils.Utils.{period, singleSpace}
 import views.html.components.newTabLink

--- a/test/views/components/NewTabLinkSpec.scala
+++ b/test/views/components/NewTabLinkSpec.scala
@@ -98,8 +98,6 @@ class NewTabLinkSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = buildApp
-
     val linkMessage: String = "go to test page"
     val href = "www.test.com"
     val preLinkMessage = "test_pre_link_message"
@@ -107,15 +105,12 @@ class NewTabLinkSpec extends SpecBase {
     val classes = "govuk-!-margin-bottom-7"
     val defaultClasses: String = "govuk-body"
 
-    implicit val msg: Messages = messages(app)
-    implicit val config: AppConfig = app.injector.instanceOf[AppConfig]
-
     def newTabLinkComponent(linkMessage: String,
                             href: String,
                             preLinkMessage: Option[String] = None,
                             postLinkMessage: Option[String] = None,
                             classes: String = defaultClasses): Document =
-      Jsoup.parse(app.injector.instanceOf[newTabLink].
+      Jsoup.parse(buildApp.injector.instanceOf[newTabLink].
         apply(linkMessage, href, preLinkMessage, postLinkMessage, classes).body)
 
   }

--- a/test/views/components/NewTabLinkSpec.scala
+++ b/test/views/components/NewTabLinkSpec.scala
@@ -107,7 +107,7 @@ class NewTabLinkSpec extends SpecBase {
                             preLinkMessage: Option[String] = None,
                             postLinkMessage: Option[String] = None,
                             classes: String = defaultClasses): Document =
-      Jsoup.parse(buildApp.injector.instanceOf[newTabLink].
+      Jsoup.parse(application.injector.instanceOf[newTabLink].
         apply(linkMessage, href, preLinkMessage, postLinkMessage, classes).body)
 
   }

--- a/test/views/components/NotificationPanelSpec.scala
+++ b/test/views/components/NotificationPanelSpec.scala
@@ -18,9 +18,6 @@ package views.components
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
-import play.api.Application
-import play.api.i18n.{Messages, MessagesApi}
-import play.api.test.FakeRequest
 import utils.SpecBase
 import utils.Utils.notificationPanelComponent
 
@@ -64,9 +61,6 @@ class NotificationPanelSpec extends SpecBase {
   }
 
   trait Setup {
-
-    val app: Application = buildApp
-    implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
 
     val showNotification: Boolean
     val preMessage: String = "preMessage"

--- a/test/views/components/NotificationPanelSpec.scala
+++ b/test/views/components/NotificationPanelSpec.scala
@@ -65,7 +65,7 @@ class NotificationPanelSpec extends SpecBase {
 
   trait Setup {
 
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
 
     val showNotification: Boolean

--- a/test/views/components/P1Spec.scala
+++ b/test/views/components/P1Spec.scala
@@ -57,7 +57,7 @@ class P1Spec extends SpecBase {
     val link: Option[Html] = Some(Html("test_Link"))
     val tabLink: Option[Html] = Some(Html("tab_link"))
 
-    val app: Application = application.build()
+    val app: Application = buildApp
 
     implicit val msgs: Messages = messages(app)
 

--- a/test/views/components/P1Spec.scala
+++ b/test/views/components/P1Spec.scala
@@ -56,7 +56,7 @@ class P1Spec extends SpecBase {
     val link: Option[Html] = Some(Html("test_Link"))
     val tabLink: Option[Html] = Some(Html("tab_link"))
 
-    val app: Application = buildApp
+    val app: Application = application
 
     val p1Component: Document =
       Jsoup.parse(app.injector.instanceOf[p1].apply(content, Some(id), Some(classes), link, tabLink).body)

--- a/test/views/components/P1Spec.scala
+++ b/test/views/components/P1Spec.scala
@@ -19,7 +19,6 @@ package views.components
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.Application
-import play.api.i18n.Messages
 import play.twirl.api.Html
 import utils.SpecBase
 import views.html.components.p1
@@ -58,8 +57,6 @@ class P1Spec extends SpecBase {
     val tabLink: Option[Html] = Some(Html("tab_link"))
 
     val app: Application = buildApp
-
-    implicit val msgs: Messages = messages(app)
 
     val p1Component: Document =
       Jsoup.parse(app.injector.instanceOf[p1].apply(content, Some(id), Some(classes), link, tabLink).body)

--- a/test/views/components/P1Spec.scala
+++ b/test/views/components/P1Spec.scala
@@ -18,10 +18,10 @@ package views.components
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.Application
 import play.twirl.api.Html
 import utils.SpecBase
 import views.html.components.p1
+import utils.Utils.singleSpace
 
 class P1Spec extends SpecBase {
 
@@ -31,7 +31,7 @@ class P1Spec extends SpecBase {
 
       "it contains all the parameters' value" in new Setup {
         p1Component.getElementById(id).text() mustBe
-          s"${content.body}$space${link.get.body}$space${tabLink.get.body}"
+          s"${content.body}$singleSpace${link.get.body}$singleSpace${tabLink.get.body}"
 
         p1Component.getElementsByClass(classes).size() mustBe 1
       }
@@ -49,21 +49,18 @@ class P1Spec extends SpecBase {
   }
 
   trait Setup {
-    val space = " "
     val content: Html = Html("test_content")
     val id: String = "test_id"
     val classes: String = "govuk-!-margin-bottom-7"
     val link: Option[Html] = Some(Html("test_Link"))
     val tabLink: Option[Html] = Some(Html("tab_link"))
 
-    val app: Application = application
-
     val p1Component: Document =
-      Jsoup.parse(app.injector.instanceOf[p1].apply(content, Some(id), Some(classes), link, tabLink).body)
+      Jsoup.parse(application.injector.instanceOf[p1].apply(content, Some(id), Some(classes), link, tabLink).body)
 
-    val p1ComponentWithContentOnly: Document = Jsoup.parse(app.injector.instanceOf[p1].apply(content).body)
+    val p1ComponentWithContentOnly: Document = Jsoup.parse(application.injector.instanceOf[p1].apply(content).body)
 
     val p1ComponentWithContentIdAndClasses: Document =
-      Jsoup.parse(app.injector.instanceOf[p1].apply(content, Some(id), Some(classes)).body)
+      Jsoup.parse(application.injector.instanceOf[p1].apply(content, Some(id), Some(classes)).body)
   }
 }

--- a/test/views/components/PSpec.scala
+++ b/test/views/components/PSpec.scala
@@ -55,7 +55,7 @@ class PSpec extends SpecBase {
     val classes = "custom_class"
     val defaultClass = "govuk-body"
 
-    val app: Application = application.build()
+    val app: Application = buildApp
 
     implicit val msgs: Messages = messages(app)
 

--- a/test/views/components/PSpec.scala
+++ b/test/views/components/PSpec.scala
@@ -18,7 +18,6 @@ package views.components
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.Application
 import utils.SpecBase
 import views.html.components.p
 
@@ -54,13 +53,11 @@ class PSpec extends SpecBase {
     val classes = "custom_class"
     val defaultClass = "govuk-body"
 
-    val app: Application = application
-
-    val pComponent: Document = Jsoup.parse(app.injector.instanceOf[p].apply(msgKey).body)
+    val pComponent: Document = Jsoup.parse(application.injector.instanceOf[p].apply(msgKey).body)
     val pComponentWithIdAndClasses: Document =
-      Jsoup.parse(app.injector.instanceOf[p].apply(msgKey, classes = classes, id = Some(id)).body)
+      Jsoup.parse(application.injector.instanceOf[p].apply(msgKey, classes = classes, id = Some(id)).body)
 
     val pComponentBoldWithIdAndClasses: Document =
-      Jsoup.parse(app.injector.instanceOf[p].apply(msgKey, classes = classes, id = Some(id), bold = true).body)
+      Jsoup.parse(application.injector.instanceOf[p].apply(msgKey, classes = classes, id = Some(id), bold = true).body)
   }
 }

--- a/test/views/components/PSpec.scala
+++ b/test/views/components/PSpec.scala
@@ -19,7 +19,6 @@ package views.components
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.Application
-import play.api.i18n.Messages
 import utils.SpecBase
 import views.html.components.p
 
@@ -30,21 +29,21 @@ class PSpec extends SpecBase {
     "display correct contents" when {
 
       "only message key has been provided" in new Setup {
-        pComponent.text() mustBe msgs(msgKey)
-        pComponent.getElementsByClass(defaultClass).text() mustBe msgs(msgKey)
+        pComponent.text() mustBe messages(msgKey)
+        pComponent.getElementsByClass(defaultClass).text() mustBe messages(msgKey)
       }
 
       "id and classes have been provided along with msg key" in new Setup {
-        pComponentWithIdAndClasses.getElementById(id).text() mustBe msgs(msgKey)
-        pComponentWithIdAndClasses.getElementsByClass(classes).text() mustBe msgs(msgKey)
+        pComponentWithIdAndClasses.getElementById(id).text() mustBe messages(msgKey)
+        pComponentWithIdAndClasses.getElementsByClass(classes).text() mustBe messages(msgKey)
       }
 
       "id, classes have been provided along with msg key and bold attribute is true" in new Setup {
-        pComponentBoldWithIdAndClasses.getElementById(id).text() mustBe msgs(msgKey)
-        pComponentBoldWithIdAndClasses.getElementsByClass(classes).text() mustBe msgs(msgKey)
+        pComponentBoldWithIdAndClasses.getElementById(id).text() mustBe messages(msgKey)
+        pComponentBoldWithIdAndClasses.getElementsByClass(classes).text() mustBe messages(msgKey)
         pComponentBoldWithIdAndClasses.getElementsByClass(defaultClass).text() mustBe empty
         pComponentBoldWithIdAndClasses.getElementsByClass(
-          "govuk-!-font-weight-bold").text() mustBe msgs(msgKey)
+          "govuk-!-font-weight-bold").text() mustBe messages(msgKey)
       }
     }
   }
@@ -56,8 +55,6 @@ class PSpec extends SpecBase {
     val defaultClass = "govuk-body"
 
     val app: Application = buildApp
-
-    implicit val msgs: Messages = messages(app)
 
     val pComponent: Document = Jsoup.parse(app.injector.instanceOf[p].apply(msgKey).body)
     val pComponentWithIdAndClasses: Document =

--- a/test/views/components/PSpec.scala
+++ b/test/views/components/PSpec.scala
@@ -54,7 +54,7 @@ class PSpec extends SpecBase {
     val classes = "custom_class"
     val defaultClass = "govuk-body"
 
-    val app: Application = buildApp
+    val app: Application = application
 
     val pComponent: Document = Jsoup.parse(app.injector.instanceOf[p].apply(msgKey).body)
     val pComponentWithIdAndClasses: Document =

--- a/test/views/components/PaymentHeaderV2Spec.scala
+++ b/test/views/components/PaymentHeaderV2Spec.scala
@@ -16,8 +16,6 @@
 
 package views.components
 
-import play.api.Application
-import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases
 import uk.gov.hmrc.govukfrontend.views.Aliases.{HeadCell, HtmlContent}
 import utils.SpecBase
@@ -36,17 +34,14 @@ class PaymentHeaderV2Spec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = buildApp
-    implicit val msgs: Messages = messages(app)
-
     protected def expectedHeaderCells: Seq[HeadCell] = {
       Seq(
         HeadCell(
           classes = "first-column-width",
           content = HtmlContent(
             s"""
-                <abbr title="${msgs("cf.cash-account.detail.date")}">
-                    ${msgs("cf.cash-account.detail.date")}
+                <abbr title="${messages("cf.cash-account.detail.date")}">
+                    ${messages("cf.cash-account.detail.date")}
                 </abbr>
                 """)
         ),
@@ -54,25 +49,16 @@ class PaymentHeaderV2Spec extends SpecBase {
           classes = "second-column-width",
           content = HtmlContent(
             s"""
-                <abbr title="${msgs("cf.cash-account.detail.transaction-type")}">
-                ${msgs("cf.cash-account.detail.transaction-type")}
+                <abbr title="${messages("cf.cash-account.detail.transaction-type")}">
+                ${messages("cf.cash-account.detail.transaction-type")}
                 </abbr>
                 """)
         ),
         HeadCell(
           content = HtmlContent(
             s"""
-                <abbr title="${msgs("cf.cash-account.detail.credit")}">
-                ${msgs("cf.cash-account.detail.credit")}
-                </abbr>
-                """)
-        ),
-        HeadCell(
-          format = Some("numeric"),
-          content = HtmlContent(
-            s"""
-                <abbr title="${msgs("cf.cash-account.detail.debit")}">
-                ${msgs("cf.cash-account.detail.debit")}
+                <abbr title="${messages("cf.cash-account.detail.credit")}">
+                ${messages("cf.cash-account.detail.credit")}
                 </abbr>
                 """)
         ),
@@ -80,7 +66,16 @@ class PaymentHeaderV2Spec extends SpecBase {
           format = Some("numeric"),
           content = HtmlContent(
             s"""
-                      ${msgs("cf.cash-account.detail.balance")}
+                <abbr title="${messages("cf.cash-account.detail.debit")}">
+                ${messages("cf.cash-account.detail.debit")}
+                </abbr>
+                """)
+        ),
+        HeadCell(
+          format = Some("numeric"),
+          content = HtmlContent(
+            s"""
+                      ${messages("cf.cash-account.detail.balance")}
                       """)
         )
       )

--- a/test/views/components/PaymentHeaderV2Spec.scala
+++ b/test/views/components/PaymentHeaderV2Spec.scala
@@ -36,7 +36,7 @@ class PaymentHeaderV2Spec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val msgs: Messages = messages(app)
 
     protected def expectedHeaderCells: Seq[HeadCell] = {

--- a/test/views/components/PaymentSearchResultHeaderV2Spec.scala
+++ b/test/views/components/PaymentSearchResultHeaderV2Spec.scala
@@ -17,8 +17,6 @@
 package views.components
 
 import org.scalatest.matchers.should.Matchers.should
-import play.api.Application
-import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases
 import uk.gov.hmrc.govukfrontend.views.Aliases.HeadCell
 import utils.SpecBase
@@ -27,7 +25,7 @@ class PaymentSearchResultHeaderV2Spec extends SpecBase {
 
   "apply" should {
 
-    "produce correct output" in new Setup {
+    "produce correct output" in {
 
       val header: Seq[HeadCell] = PaymentSearchResultHeader()
 
@@ -38,11 +36,6 @@ class PaymentSearchResultHeaderV2Spec extends SpecBase {
       header.last.content.toString.contains("Debit") mustBe true
       header.last.format.get.contains("numeric") mustBe true
     }
-  }
-
-  trait Setup {
-    val app: Application = buildApp
-    implicit val msgs: Messages = messages(app)
   }
 
 }

--- a/test/views/components/PaymentSearchResultHeaderV2Spec.scala
+++ b/test/views/components/PaymentSearchResultHeaderV2Spec.scala
@@ -41,7 +41,7 @@ class PaymentSearchResultHeaderV2Spec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val msgs: Messages = messages(app)
   }
 

--- a/test/views/components/SummaryListSpec.scala
+++ b/test/views/components/SummaryListSpec.scala
@@ -19,7 +19,6 @@ package views.components
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.Application
-import play.api.i18n.Messages
 import utils.SpecBase
 import viewmodels.ResultsPageSummary
 import views.html.components.summaryList
@@ -48,7 +47,6 @@ class SummaryListSpec extends SpecBase {
 
   trait Setup {
     val app: Application = buildApp
-    implicit val msgs: Messages = messages(app)
 
     val day10th = 10
     val day11th = 11

--- a/test/views/components/SummaryListSpec.scala
+++ b/test/views/components/SummaryListSpec.scala
@@ -18,7 +18,6 @@ package views.components
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.Application
 import utils.SpecBase
 import viewmodels.ResultsPageSummary
 import views.html.components.summaryList
@@ -46,8 +45,6 @@ class SummaryListSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application
-
     val day10th = 10
     val day11th = 11
     val month = 3
@@ -65,9 +62,9 @@ class SummaryListSpec extends SpecBase {
     val summary: ResultsPageSummary = new ResultsPageSummary(fromDate, toDate)
 
     val summaryListComponent: Document = Jsoup.parse(
-      app.injector.instanceOf[summaryList].apply(summary = summary).body)
+      application.injector.instanceOf[summaryList].apply(summary = summary).body)
 
     val summaryListComponentWithChange: Document = Jsoup.parse(
-      app.injector.instanceOf[summaryList].apply(summary = summary, isChange = true).body)
+      application.injector.instanceOf[summaryList].apply(summary = summary, isChange = true).body)
   }
 }

--- a/test/views/components/SummaryListSpec.scala
+++ b/test/views/components/SummaryListSpec.scala
@@ -46,7 +46,7 @@ class SummaryListSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = buildApp
+    val app: Application = application
 
     val day10th = 10
     val day11th = 11

--- a/test/views/components/SummaryListSpec.scala
+++ b/test/views/components/SummaryListSpec.scala
@@ -47,7 +47,7 @@ class SummaryListSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
+    val app: Application = buildApp
     implicit val msgs: Messages = messages(app)
 
     val day10th = 10

--- a/test/views/components/inputMonthAndYearSpec.scala
+++ b/test/views/components/inputMonthAndYearSpec.scala
@@ -20,7 +20,6 @@ import forms.SelectTransactionsFormProvider
 import models.CashTransactionDates
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.Application
 import play.api.data.Form
 import play.api.test.Helpers.*
 import play.twirl.api.HtmlFormat
@@ -41,8 +40,8 @@ class inputMonthAndYearSpec extends SpecBase {
         )
       )
 
-      running(app) {
-        val inputDateView = app.injector.instanceOf[inputMonthAndYear]
+      running(application) {
+        val inputDateView = application.injector.instanceOf[inputMonthAndYear]
 
         val output: HtmlFormat.Appendable = inputDateView(
           formWithValues,
@@ -72,8 +71,8 @@ class inputMonthAndYearSpec extends SpecBase {
         )
       )
 
-      running(app) {
-        val inputDateView = app.injector.instanceOf[inputMonthAndYear]
+      running(application) {
+        val inputDateView = application.injector.instanceOf[inputMonthAndYear]
 
         val output: HtmlFormat.Appendable = inputDateView(
           formWithValues,
@@ -103,8 +102,8 @@ class inputMonthAndYearSpec extends SpecBase {
         )
       )
 
-      running(app) {
-        val inputDateView = app.injector.instanceOf[inputMonthAndYear]
+      running(application) {
+        val inputDateView = application.injector.instanceOf[inputMonthAndYear]
 
         val output: HtmlFormat.Appendable = inputDateView(
           formWithValues,
@@ -134,8 +133,8 @@ class inputMonthAndYearSpec extends SpecBase {
         )
       )
 
-      running(app) {
-        val inputDateView = app.injector.instanceOf[inputMonthAndYear]
+      running(application) {
+        val inputDateView = application.injector.instanceOf[inputMonthAndYear]
 
         val output: HtmlFormat.Appendable = inputDateView(
           formWithValues,
@@ -162,8 +161,6 @@ class inputMonthAndYearSpec extends SpecBase {
       val form: Form[CashTransactionDates] = new SelectTransactionsFormProvider().apply()
       val id: String = "value"
       val headline: String = "Date of birth"
-
-      val app: Application = application
     }
   }
 }

--- a/test/views/components/inputMonthAndYearSpec.scala
+++ b/test/views/components/inputMonthAndYearSpec.scala
@@ -52,7 +52,7 @@ class inputMonthAndYearSpec extends SpecBase {
           legendClasses = "legend-class",
           hintText = None,
           legendAsPageHeading = false
-        )(messages(app))
+        )(messages)
 
         val html: Document = Jsoup.parse(output.toString)
 
@@ -83,7 +83,7 @@ class inputMonthAndYearSpec extends SpecBase {
           legendClasses = "legend-class",
           hintText = None,
           legendAsPageHeading = false
-        )(messages(app))
+        )(messages)
 
         val html: Document = Jsoup.parse(output.toString)
 
@@ -114,7 +114,7 @@ class inputMonthAndYearSpec extends SpecBase {
           legendClasses = "legend-class",
           hintText = None,
           legendAsPageHeading = false
-        )(messages(app))
+        )(messages)
 
         val html: Document = Jsoup.parse(output.toString)
 
@@ -145,7 +145,7 @@ class inputMonthAndYearSpec extends SpecBase {
           legendClasses = "legend-class",
           hintText = None,
           legendAsPageHeading = false
-        )(messages(app))
+        )(messages)
 
         val html: Document = Jsoup.parse(output.toString)
 

--- a/test/views/components/inputMonthAndYearSpec.scala
+++ b/test/views/components/inputMonthAndYearSpec.scala
@@ -163,7 +163,7 @@ class inputMonthAndYearSpec extends SpecBase {
       val id: String = "value"
       val headline: String = "Date of birth"
 
-      val app: Application = application.build()
+      val app: Application = buildApp
     }
   }
 }

--- a/test/views/components/inputMonthAndYearSpec.scala
+++ b/test/views/components/inputMonthAndYearSpec.scala
@@ -163,7 +163,7 @@ class inputMonthAndYearSpec extends SpecBase {
       val id: String = "value"
       val headline: String = "Date of birth"
 
-      val app: Application = buildApp
+      val app: Application = application
     }
   }
 }

--- a/test/views/email/UndeliverableEmailSpec.scala
+++ b/test/views/email/UndeliverableEmailSpec.scala
@@ -17,12 +17,10 @@
 package views.email
 
 import utils.SpecBase
-import config.AppConfig
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.Application
 import play.api.mvc.AnyContentAsEmpty
-import play.api.i18n.Messages
 import play.api.test.FakeRequest
 import views.html.email.undeliverable_email
 
@@ -32,21 +30,21 @@ class UndeliverableEmailSpec extends SpecBase {
 
     "display correct guidance and text" in new Setup {
       view.title() mustBe
-        s"${messages(app)("cf.undeliverable.email.title")} - ${messages(app)("service.name")} - GOV.UK"
+        s"${messages("cf.undeliverable.email.title")} - ${messages("service.name")} - GOV.UK"
 
-      view.getElementsByTag("h1").text() mustBe messages(app)("cf.undeliverable.email.heading")
+      view.getElementsByTag("h1").text() mustBe messages("cf.undeliverable.email.heading")
 
-      view.text().contains(messages(app)("cf.undeliverable.email.p1")) mustBe true
-      view.html.contains(messages(app)("cf.undeliverable.email.p2", email))
+      view.text().contains(messages("cf.undeliverable.email.p1")) mustBe true
+      view.html.contains(messages("cf.undeliverable.email.p2", email))
 
-      view.text().contains(messages(app)("cf.undeliverable.email.verify.heading")) mustBe true
-      view.text().contains(messages(app)("cf.undeliverable.email.verify.text.p1")) mustBe true
-      view.text().contains(messages(app)("cf.undeliverable.email.change.heading")) mustBe true
+      view.text().contains(messages("cf.undeliverable.email.verify.heading")) mustBe true
+      view.text().contains(messages("cf.undeliverable.email.verify.text.p1")) mustBe true
+      view.text().contains(messages("cf.undeliverable.email.change.heading")) mustBe true
 
-      view.text().contains(messages(app)("cf.undeliverable.email.change.text.p1")) mustBe true
-      view.text().contains(messages(app)("cf.undeliverable.email.change.text.p2")) mustBe true
+      view.text().contains(messages("cf.undeliverable.email.change.text.p1")) mustBe true
+      view.text().contains(messages("cf.undeliverable.email.change.text.p2")) mustBe true
 
-      view.text().contains(messages(app)("cf.undeliverable.email.link-text")) mustBe true
+      view.text().contains(messages("cf.undeliverable.email.link-text")) mustBe true
 
       view.toString must include(nextPageUrl)
       view.text().contains(email.get) mustBe true
@@ -62,9 +60,7 @@ class UndeliverableEmailSpec extends SpecBase {
     val nextPageUrl = "test_url"
     val email: Option[String] = Some("test@test.com")
 
-    implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
-    implicit val msg: Messages = messages(app)
 
     val view: Document = Jsoup.parse(
       app.injector.instanceOf[undeliverable_email].apply(nextPageUrl, email).body)

--- a/test/views/email/UndeliverableEmailSpec.scala
+++ b/test/views/email/UndeliverableEmailSpec.scala
@@ -58,7 +58,7 @@ class UndeliverableEmailSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
+    val app: Application = buildApp
     val nextPageUrl = "test_url"
     val email: Option[String] = Some("test@test.com")
 

--- a/test/views/email/UndeliverableEmailSpec.scala
+++ b/test/views/email/UndeliverableEmailSpec.scala
@@ -19,7 +19,6 @@ package views.email
 import utils.SpecBase
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.Application
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import views.html.email.undeliverable_email
@@ -56,16 +55,15 @@ class UndeliverableEmailSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application
     val nextPageUrl = "test_url"
     val email: Option[String] = Some("test@test.com")
 
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val view: Document = Jsoup.parse(
-      app.injector.instanceOf[undeliverable_email].apply(nextPageUrl, email).body)
+      application.injector.instanceOf[undeliverable_email].apply(nextPageUrl, email).body)
 
     val viewWithNoEmail: Document = Jsoup.parse(
-      app.injector.instanceOf[undeliverable_email].apply(nextPageUrl, None).body)
+      application.injector.instanceOf[undeliverable_email].apply(nextPageUrl, None).body)
   }
 }

--- a/test/views/email/UndeliverableEmailSpec.scala
+++ b/test/views/email/UndeliverableEmailSpec.scala
@@ -56,7 +56,7 @@ class UndeliverableEmailSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = buildApp
+    val app: Application = application
     val nextPageUrl = "test_url"
     val email: Option[String] = Some("test@test.com")
 

--- a/test/views/email/VerifyYourEmailSpec.scala
+++ b/test/views/email/VerifyYourEmailSpec.scala
@@ -53,7 +53,7 @@ class VerifyYourEmailSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application.build()
+    val app: Application = buildApp
     val nextPageUrl = "test_url"
     val email: Option[String] = Some("test@test.com")
 

--- a/test/views/email/VerifyYourEmailSpec.scala
+++ b/test/views/email/VerifyYourEmailSpec.scala
@@ -16,11 +16,9 @@
 
 package views.email
 
-import config.AppConfig
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.Application
-import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import utils.SpecBase
@@ -33,15 +31,15 @@ class VerifyYourEmailSpec extends SpecBase {
     "display correct guidance and text" in new Setup {
 
       view.title() mustBe
-        s"${messages(app)("cf.verify.your.email.title")} - ${messages(app)("service.name")} - GOV.UK"
+        s"${messages("cf.verify.your.email.title")} - ${messages("service.name")} - GOV.UK"
 
-      view.getElementsByTag("h1").text() mustBe messages(app)("cf.verify.your.email.heading")
+      view.getElementsByTag("h1").text() mustBe messages("cf.verify.your.email.heading")
 
-      view.text().contains(messages(app)("cf.verify.your.email.p1")) mustBe true
-      view.html.contains(messages(app)("cf.verify.your.email.p2", email))
+      view.text().contains(messages("cf.verify.your.email.p1")) mustBe true
+      view.html.contains(messages("cf.verify.your.email.p2", email))
 
-      view.text().contains(messages(app)("cf.verify.your.email.p3")) mustBe true
-      view.text().contains(messages(app)("cf.verify.your.email.change.button")) mustBe true
+      view.text().contains(messages("cf.verify.your.email.p3")) mustBe true
+      view.text().contains(messages("cf.verify.your.email.change.button")) mustBe true
 
       view.html() must include(nextPageUrl)
       view.text().contains(email.get) mustBe true
@@ -57,8 +55,6 @@ class VerifyYourEmailSpec extends SpecBase {
     val nextPageUrl = "test_url"
     val email: Option[String] = Some("test@test.com")
 
-    implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
-    implicit val msg: Messages = messages(app)
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val view: Document = Jsoup.parse(

--- a/test/views/email/VerifyYourEmailSpec.scala
+++ b/test/views/email/VerifyYourEmailSpec.scala
@@ -51,7 +51,7 @@ class VerifyYourEmailSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = buildApp
+    val app: Application = application
     val nextPageUrl = "test_url"
     val email: Option[String] = Some("test@test.com")
 

--- a/test/views/email/VerifyYourEmailSpec.scala
+++ b/test/views/email/VerifyYourEmailSpec.scala
@@ -18,7 +18,6 @@ package views.email
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.Application
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import utils.SpecBase
@@ -51,17 +50,15 @@ class VerifyYourEmailSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application = application
     val nextPageUrl = "test_url"
     val email: Option[String] = Some("test@test.com")
 
     implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
 
     val view: Document = Jsoup.parse(
-      app.injector.instanceOf[verify_your_email].apply(nextPageUrl, email).body)
+      application.injector.instanceOf[verify_your_email].apply(nextPageUrl, email).body)
 
     val viewWithNoEmail: Document = Jsoup.parse(
-      app.injector.instanceOf[verify_your_email].apply(nextPageUrl).body)
-
+      application.injector.instanceOf[verify_your_email].apply(nextPageUrl).body)
   }
 }

--- a/test/views/helpers/PageTitleSpec.scala
+++ b/test/views/helpers/PageTitleSpec.scala
@@ -17,27 +17,22 @@
 package views.helpers
 
 import utils.SpecBase
-import play.api.i18n.Messages
-import play.api.test.Helpers
 
 class PageTitleSpec extends SpecBase {
 
   "fullPageTitle" should {
 
-    "return correct string for present title" in new Setup {
+    "return correct string for present title" in {
       val res: Option[String] = PageTitle.fullPageTitle(Some("abc"))
 
-      res mustBe Some("abc - service.name - GOV.UK")
+      res mustBe Some("abc - Manage import duties and VAT accounts - GOV.UK")
     }
 
-    "return correct string for no title" in new Setup {
+    "return correct string for no title" in {
       val res: Option[String] = PageTitle.fullPageTitle(Some(""))
 
-      res mustBe Some(" - service.name - GOV.UK")
+      res mustBe Some(" - Manage import duties and VAT accounts - GOV.UK")
     }
   }
 
-  trait Setup {
-    implicit val msgs: Messages = Helpers.stubMessages()
-  }
 }


### PR DESCRIPTION
Description - Code changes to use of common instance of GuiceApplicationBuilder, AppConfig and Messages

Below have been done as part of this PR

- [ ] convert the def into lazy vals in order to instantiate only once in SpecBase
- [ ] update tests to make use of common instance of AppConfig,  GuiceApplicationBuilder and Messages
- [ ] remove unused imports as these have become redundant after referring to the common instances
- [ ] remove the Setup trait (wherever it became redundant)
- [ ] minor refactoring