### PR TITLE
[MMCA-4999] - Implement Start date & End date field errors on cash account transaction request journey

### DIFF
--- a/app/forms/SelectTransactionsFormProvider.scala
+++ b/app/forms/SelectTransactionsFormProvider.scala
@@ -31,9 +31,9 @@ class SelectTransactionsFormProvider @Inject()(implicit clock: Clock)
     Form(
       mapping(
         "start" -> localDate(
-          invalidKey = "cf.form.error.start.date.empty.month.year",
-          monthKey = "cf.form.error.start.date.empty.month",
-          yearKey = "cf.form.error.start.date.empty.year",
+          emptyMonthAndYearKey = "cf.form.error.start.date.empty.month.year",
+          emptyMonthKey = "cf.form.error.start.date.empty.month",
+          emptyYearKey = "cf.form.error.start.date.empty.year",
           invalidDateKey = "cf.form.error.start.date.invalid"
         ).verifying(
           beforeCurrentDate(errorKey = "cf.form.error.start-future-date")
@@ -45,9 +45,9 @@ class SelectTransactionsFormProvider @Inject()(implicit clock: Clock)
           )
         ),
         "end" -> localDate(
-          invalidKey = "cf.form.error.end.date.empty.month.year",
-          monthKey = "cf.form.error.end.date.empty.month",
-          yearKey = "cf.form.error.end.date.empty.year",
+          emptyMonthAndYearKey = "cf.form.error.end.date.empty.month.year",
+          emptyMonthKey = "cf.form.error.end.date.empty.month",
+          emptyYearKey = "cf.form.error.end.date.empty.year",
           invalidDateKey = "cf.form.error.end.date.invalid",
           useLastDayOfMonth = true
         ).verifying(

--- a/app/forms/SelectTransactionsFormProvider.scala
+++ b/app/forms/SelectTransactionsFormProvider.scala
@@ -34,7 +34,7 @@ class SelectTransactionsFormProvider @Inject()(implicit clock: Clock)
           invalidKey = "cf.form.error.start.date.empty.month.year",
           monthKey = "cf.form.error.start.date.empty.month",
           yearKey = "cf.form.error.start.date.empty.year",
-          invalidDateKey = "cf.form.error.start.date.invalid.real-date"
+          invalidDateKey = "cf.form.error.start.date.invalid"
         ).verifying(
           beforeCurrentDate(errorKey = "cf.form.error.start-future-date")
         ).verifying(
@@ -48,7 +48,7 @@ class SelectTransactionsFormProvider @Inject()(implicit clock: Clock)
           invalidKey = "cf.form.error.end.date.empty.month.year",
           monthKey = "cf.form.error.end.date.empty.month",
           yearKey = "cf.form.error.end.date.empty.year",
-          invalidDateKey = "cf.form.error.end.date.invalid.real-date",
+          invalidDateKey = "cf.form.error.end.date.invalid",
           useLastDayOfMonth = true
         ).verifying(
           beforeCurrentDate(errorKey = "cf.form.error.end-future-date")

--- a/app/forms/SelectTransactionsFormProvider.scala
+++ b/app/forms/SelectTransactionsFormProvider.scala
@@ -31,10 +31,10 @@ class SelectTransactionsFormProvider @Inject()(implicit clock: Clock)
     Form(
       mapping(
         "start" -> localDate(
-          emptyMonthAndYearKey = "cf.form.error.start.date.empty.month.year",
-          emptyMonthKey = "cf.form.error.start.date.empty.month",
-          emptyYearKey = "cf.form.error.start.date.empty.year",
-          invalidDateKey = "cf.form.error.start.date.invalid"
+          emptyMonthAndYearKey = "cf.cash-account.transactions.request.start.date.empty.month.year",
+          emptyMonthKey = "cf.cash-account.transactions.request.start.date.empty.month",
+          emptyYearKey = "cf.cash-account.transactions.request.start.date.empty.year",
+          invalidDateKey = "cf.cash-account.transactions.request.start.date.invalid"
         ).verifying(
           beforeCurrentDate(errorKey = "cf.form.error.start-future-date")
         ).verifying(
@@ -45,10 +45,10 @@ class SelectTransactionsFormProvider @Inject()(implicit clock: Clock)
           )
         ),
         "end" -> localDate(
-          emptyMonthAndYearKey = "cf.form.error.end.date.empty.month.year",
-          emptyMonthKey = "cf.form.error.end.date.empty.month",
-          emptyYearKey = "cf.form.error.end.date.empty.year",
-          invalidDateKey = "cf.form.error.end.date.invalid",
+          emptyMonthAndYearKey = "cf.cash-account.transactions.request.end.date.empty.month.year",
+          emptyMonthKey = "cf.cash-account.transactions.request.end.date.empty.month",
+          emptyYearKey = "cf.cash-account.transactions.request.end.date.empty.year",
+          invalidDateKey = "cf.cash-account.transactions.request.end.date.invalid",
           useLastDayOfMonth = true
         ).verifying(
           beforeCurrentDate(errorKey = "cf.form.error.end-future-date")

--- a/app/forms/SelectTransactionsFormProvider.scala
+++ b/app/forms/SelectTransactionsFormProvider.scala
@@ -41,7 +41,7 @@ class SelectTransactionsFormProvider @Inject()(implicit clock: Clock)
           checkDates(
             systemStartDateErrorKey = "cf.form.error.startDate.date-earlier-than-system-start-date",
             taxYearErrorKey = "cf.form.error.start.date-too-far-in-past",
-            invalidLength = "cf.form.error.year.length"
+            invalidLength = "date.year.length.invalid"
           )
         ),
         "end" -> localDate(
@@ -56,7 +56,7 @@ class SelectTransactionsFormProvider @Inject()(implicit clock: Clock)
           checkDates(
             systemStartDateErrorKey = "cf.form.error.endDate.date-earlier-than-system-start-date",
             taxYearErrorKey = "cf.form.error.end.date-too-far-in-past",
-            invalidLength = "cf.form.error.year.length"
+            invalidLength = "date.year.length.invalid"
           )
         )
       )(CashTransactionDates.apply)(ctd => Some(Tuple.fromProductTyped(ctd)))

--- a/app/forms/SelectTransactionsFormProvider.scala
+++ b/app/forms/SelectTransactionsFormProvider.scala
@@ -31,9 +31,9 @@ class SelectTransactionsFormProvider @Inject()(implicit clock: Clock)
     Form(
       mapping(
         "start" -> localDate(
-          invalidKey = "cf.form.error.start.date-number-invalid",
-          monthKey = "cf.form.error.start.date.invalid.month",
-          yearKey = "cf.form.error.start.date.invalid.year",
+          invalidKey = "cf.form.error.start.date.empty.month.year",
+          monthKey = "cf.form.error.start.date.empty.month",
+          yearKey = "cf.form.error.start.date.empty.year",
           invalidDateKey = "cf.form.error.start.date.invalid.real-date"
         ).verifying(
           beforeCurrentDate(errorKey = "cf.form.error.start-future-date")
@@ -45,9 +45,9 @@ class SelectTransactionsFormProvider @Inject()(implicit clock: Clock)
           )
         ),
         "end" -> localDate(
-          invalidKey = "cf.form.error.end.date-number-invalid",
-          monthKey = "cf.form.error.end.date.invalid.month",
-          yearKey = "cf.form.error.end.date.invalid.year",
+          invalidKey = "cf.form.error.end.date.empty.month.year",
+          monthKey = "cf.form.error.end.date.empty.month",
+          yearKey = "cf.form.error.end.date.empty.year",
           invalidDateKey = "cf.form.error.end.date.invalid.real-date",
           useLastDayOfMonth = true
         ).verifying(

--- a/app/forms/mappings/SelectLocalDateFormatter.scala
+++ b/app/forms/mappings/SelectLocalDateFormatter.scala
@@ -33,6 +33,10 @@ private[mappings] class SelectLocalDateFormatter(invalidKey: String,
   val log: LoggerLike = Logger(this.getClass)
 
   private val fieldKeys: List[String] = List("month", "year")
+  private val monthValueMin = 1
+  private val monthValueMax = 12
+  private val yearValueMin = 1000
+  private val yearValueMax = 99999
 
   override def bind(key: String,
                     data: Map[String, String]): Either[Seq[FormError], LocalDate] = {
@@ -78,8 +82,8 @@ private[mappings] class SelectLocalDateFormatter(invalidKey: String,
                                             month: Int,
                                             year: Int): String =
     (month, year) match {
-      case (m, _) if m < 1 || m > 12 => s"$key.month"
-      case (_, y) if y < 1000 || y > 99999 => s"$key.year"
+      case (m, _) if m < monthValueMin || m > monthValueMax => s"$key.month"
+      case (_, y) if y < yearValueMin || y > yearValueMax => s"$key.year"
       case _ => s"$key.month"
     }
 

--- a/app/forms/mappings/SelectLocalDateFormatter.scala
+++ b/app/forms/mappings/SelectLocalDateFormatter.scala
@@ -23,9 +23,9 @@ import play.api.{Logger, LoggerLike}
 import java.time.{LocalDate, LocalDateTime, YearMonth}
 import scala.util.{Failure, Success, Try}
 
-private[mappings] class SelectLocalDateFormatter(invalidKey: String,
-                                                 monthKey: String,
-                                                 yearKey: String,
+private[mappings] class SelectLocalDateFormatter(emptyMonthAndYearKey: String,
+                                                 emptyMonthKey: String,
+                                                 emptyYearKey: String,
                                                  invalidDateKey: String,
                                                  args: Seq[String],
                                                  useLastDayOfMonth: Boolean) extends Formatter[LocalDate] with Formatters {
@@ -50,7 +50,7 @@ private[mappings] class SelectLocalDateFormatter(invalidKey: String,
         List(
           FormError(
             formErrorKeysInCaseOfEmptyOrNonNumericValues(key, data),
-            invalidKey,
+            emptyMonthAndYearKey,
             args
           )
         )
@@ -90,8 +90,8 @@ private[mappings] class SelectLocalDateFormatter(invalidKey: String,
   private def checkForFieldValues(key: String,
                                   data: Map[String, String]): Either[Seq[FormError], LocalDate] = {
     data match {
-      case value if isMonthEmpty(key, value) => populateErrorMsg(key, data, monthKey)
-      case value if isYearEmpty(key, value) => populateErrorMsg(key, data, yearKey)
+      case value if isMonthEmpty(key, value) => populateErrorMsg(key, data, emptyMonthKey)
+      case value if isYearEmpty(key, value) => populateErrorMsg(key, data, emptyYearKey)
       case _ => createDateOrGenerateFormError(key, data)
     }
   }

--- a/app/forms/mappings/SelectLocalDateFormatter.scala
+++ b/app/forms/mappings/SelectLocalDateFormatter.scala
@@ -98,6 +98,25 @@ private[mappings] class SelectLocalDateFormatter(invalidKey: String,
     }
   }
 
+  private def formatDate(key: String,
+                         data: Map[String, String]): Either[Seq[FormError], LocalDate] = {
+
+    val int = intFormatter(
+      requiredKey = invalidDateKey,
+      wholeNumberKey = invalidDateKey,
+      nonNumericKey = invalidDateKey,
+      args
+    )
+
+    for {
+      month <- int.bind(s"$key.month", data)
+      year <- int.bind(s"$key.year", data)
+      date <- toDate(key, month, year)
+    } yield {
+      date
+    }
+  }
+
   private def toDate(key: String,
                      month: Int,
                      year: Int): Either[Seq[FormError], LocalDate] = {
@@ -119,25 +138,6 @@ private[mappings] class SelectLocalDateFormatter(invalidKey: String,
             )
           )
       }
-    }
-  }
-
-  private def formatDate(key: String,
-                         data: Map[String, String]): Either[Seq[FormError], LocalDate] = {
-
-    val int = intFormatter(
-      requiredKey = invalidDateKey,
-      wholeNumberKey = invalidDateKey,
-      nonNumericKey = invalidDateKey,
-      args
-    )
-
-    for {
-      month <- int.bind(s"$key.month", data)
-      year <- int.bind(s"$key.year", data)
-      date <- toDate(key, month, year)
-    } yield {
-      date
     }
   }
 

--- a/app/forms/mappings/SelectLocalDateFormatter.scala
+++ b/app/forms/mappings/SelectLocalDateFormatter.scala
@@ -41,8 +41,23 @@ private[mappings] class SelectLocalDateFormatter(invalidKey: String,
       field -> data.get(s"$key.$field").filter(_.nonEmpty)
     }.toMap
 
+    if(fields.count(_._2.isDefined) == 0) {
+      Left(
+        List(
+          FormError(
+            formErrorKeysInCaseOfEmptyOrNonNumericValues(key, data),
+            invalidKey,
+            args
+          )
+        )
+      )
+    } else {
+      checkForFieldValues(key, data)
+    }
+/*
     fields.count(_._2.isDefined) match {
       case 2 | 3 => checkForFieldValues(key, data)
+      case 1 => checkForFieldValues(key, data)
       case _ =>
         Left(
           List(
@@ -53,7 +68,7 @@ private[mappings] class SelectLocalDateFormatter(invalidKey: String,
             )
           )
         )
-    }
+    }*/
   }
 
   override def unbind(key: String, value: LocalDate): Map[String, String] =

--- a/app/forms/mappings/SelectLocalDateFormatter.scala
+++ b/app/forms/mappings/SelectLocalDateFormatter.scala
@@ -90,15 +90,9 @@ private[mappings] class SelectLocalDateFormatter(invalidKey: String,
   private def checkForFieldValues(key: String,
                                   data: Map[String, String]): Either[Seq[FormError], LocalDate] = {
     data match {
-      case value if value.contains(s"$key.month") && value(s"$key.month").isEmpty =>
-        populateErrorMsg(key, data, monthKey)
-
-      case value if value.contains(s"$key.year") && data(s"$key.year").isEmpty => populateErrorMsg(key, data, yearKey)
-
-      case _ =>
-        formatDate(key, data).left.map {
-          _.map(fe => fe.copy(key = fe.key, args = args))
-        }
+      case value if isMonthEmpty(key, value) => populateErrorMsg(key, data, monthKey)
+      case value if isYearEmpty(key, value) => populateErrorMsg(key, data, yearKey)
+      case _ => createDateOrGenerateFormError(key, data)
     }
   }
 
@@ -157,6 +151,20 @@ private[mappings] class SelectLocalDateFormatter(invalidKey: String,
         )
       )
     )
+  }
+
+  private def isMonthEmpty(key: String, value: Map[String, String]) = {
+    value.contains(s"$key.month") && value(s"$key.month").isEmpty
+  }
+
+  private def isYearEmpty(key: String, value: Map[String, String]) = {
+    value.contains(s"$key.year") && value(s"$key.year").isEmpty
+  }
+
+  private def createDateOrGenerateFormError(key: String, data: Map[String, String]) = {
+    formatDate(key, data).left.map {
+      _.map(fe => fe.copy(key = fe.key, args = args))
+    }
   }
 
 }

--- a/app/forms/mappings/SelectLocalDateFormatter.scala
+++ b/app/forms/mappings/SelectLocalDateFormatter.scala
@@ -119,7 +119,7 @@ private[mappings] class SelectLocalDateFormatter(emptyMonthAndYearKey: String,
                      month: Int,
                      year: Int): Either[Seq[FormError], LocalDate] = {
 
-    if (month < 1 || month > 12) {
+    if (month < monthValueMin || month > monthValueMax) {
       Left(Seq(FormError(s"$key.month", invalidDateKey, args)))
     } else {
       val day = if (useLastDayOfMonth) YearMonth.of(year, month).lengthOfMonth() else 1

--- a/app/forms/mappings/SelectLocalDateFormatter.scala
+++ b/app/forms/mappings/SelectLocalDateFormatter.scala
@@ -41,7 +41,7 @@ private[mappings] class SelectLocalDateFormatter(invalidKey: String,
       field -> data.get(s"$key.$field").filter(_.nonEmpty)
     }.toMap
 
-    if(fields.count(_._2.isDefined) == 0) {
+    if (fields.count(_._2.isDefined) == 0) {
       Left(
         List(
           FormError(
@@ -54,21 +54,6 @@ private[mappings] class SelectLocalDateFormatter(invalidKey: String,
     } else {
       checkForFieldValues(key, data)
     }
-/*
-    fields.count(_._2.isDefined) match {
-      case 2 | 3 => checkForFieldValues(key, data)
-      case 1 => checkForFieldValues(key, data)
-      case _ =>
-        Left(
-          List(
-            FormError(
-              formErrorKeysInCaseOfEmptyOrNonNumericValues(key, data),
-              invalidKey,
-              args
-            )
-          )
-        )
-    }*/
   }
 
   override def unbind(key: String, value: LocalDate): Map[String, String] =

--- a/app/forms/mappings/SelectLocalDateFormatter.scala
+++ b/app/forms/mappings/SelectLocalDateFormatter.scala
@@ -126,9 +126,9 @@ private[mappings] class SelectLocalDateFormatter(invalidKey: String,
                          data: Map[String, String]): Either[Seq[FormError], LocalDate] = {
 
     val int = intFormatter(
-      requiredKey = invalidKey,
-      wholeNumberKey = invalidKey,
-      nonNumericKey = invalidKey,
+      requiredKey = invalidDateKey,
+      wholeNumberKey = invalidDateKey,
+      nonNumericKey = invalidDateKey,
       args
     )
 

--- a/app/forms/mappings/SelectMappings.scala
+++ b/app/forms/mappings/SelectMappings.scala
@@ -27,13 +27,21 @@ trait SelectMappings extends Formatters with Constraints {
                         invalidKey: String = "error.boolean"): FieldMapping[Boolean] =
     of(booleanFormatter(requiredKey, invalidKey))
 
-  protected def localDate(invalidKey: String,
-                          monthKey: String,
-                          yearKey: String,
+  protected def localDate(emptyMonthAndYearKey: String,
+                          emptyMonthKey: String,
+                          emptyYearKey: String,
                           invalidDateKey: String,
                           useLastDayOfMonth: Boolean = false): FieldMapping[LocalDate] = {
 
-    of(new SelectLocalDateFormatter(invalidKey, monthKey, yearKey, invalidDateKey, Seq.empty, useLastDayOfMonth))
+    of(
+      new SelectLocalDateFormatter(
+        emptyMonthAndYearKey,
+        emptyMonthKey,
+        emptyYearKey,
+        invalidDateKey,
+        Seq.empty,
+        useLastDayOfMonth)
+    )
   }
 
   protected def decimal(requiredKey: String = "error.required",

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -252,6 +252,18 @@ cf.cash-account.requested.statements.available.text.pre=Mae’r
 cf.cash-account.requested.statements.available.link.text=trafodion y gwnaethoch gais amdanynt
 cf.cash-account.requested.statements.available.text.post=bellach ar gael
 
+# Request cash Transactions
+cf.cash-account.transactions.request.start.date.empty.month = Yn eich cais am drafodion, nodwch o ba fis yr hoffech eu cael
+cf.cash-account.transactions.request.start.date.empty.year = Yn eich cais am drafodion, nodwch o ba flwyddyn yr hoffech eu cael
+cf.cash-account.transactions.request.start.date.empty.month.year = Yn eich cais am drafodion, nodwch o ba fis a blwyddyn yr hoffech eu cael
+cf.cash-account.transactions.request.start.date.invalid = Mae’n rhaid i’r dyddiad dechrau fod yn ddyddiad go iawn
+
+cf.cash-account.transactions.request.end.date.empty.month = Yn eich cais am drafodion, nodwch hyd at ba fis yr hoffech eu cael
+cf.cash-account.transactions.request.end.date.empty.year = Yn eich cais am drafodion, nodwch hyd at ba flwyddyn yr hoffech eu cael
+cf.cash-account.transactions.request.end.date.empty.month.year = Yn eich cais am drafodion, nodwch hyd at ba fis a blwyddyn yr hoffech eu cael
+cf.cash-account.transactions.request.end.date.invalid = Mae’n rhaid i’r dyddiad dod i ben fod yn ddyddiad go iawn
+
+# Date form error
 cf.form.error.start.date-too-far-in-past=Ni all y dyddiad ‘o’ fod yn fwy na 6 o flynyddoedd ers nawr.
 cf.form.error.end.date-too-far-in-past=Ni all y dyddiad ‘i’ fod yn fwy na 6 o flynyddoedd ers nawr.
 cf.form.error.year.length = Mae’n rhaid i’r flwyddyn gynnwys pedwar rhif
@@ -268,19 +280,11 @@ cf.form.error.start.date.invalid.day=Mae’n rhaid i’r dyddiad o gynnwys diwrn
 cf.form.error.start.date.invalid.month=Mae’n rhaid i’r dyddiad i gynnwys mis
 cf.form.error.start.date.invalid.year=Mae’n rhaid i’r dyddiad o gynnwys blwyddyn
 cf.form.error.start.date.invalid.real-date=Mae’n rhaid i’r dyddiad o fod yn ddyddiad go iawn
-cf.form.error.start.date.empty.month = Yn eich cais am drafodion, nodwch o ba fis yr hoffech eu cael
-cf.form.error.start.date.empty.year = Yn eich cais am drafodion, nodwch o ba flwyddyn yr hoffech eu cael
-cf.form.error.start.date.empty.month.year = Yn eich cais am drafodion, nodwch o ba fis a blwyddyn yr hoffech eu cael
-cf.form.error.start.date.invalid = Mae’n rhaid i’r dyddiad dechrau fod yn ddyddiad go iawn
 
 cf.form.error.end.date.invalid.day=Mae’n rhaid i’r dyddiad dod i ben gynnwys diwrnod
 cf.form.error.end.date.invalid.month=Mae’n rhaid i’r dyddiad dod i ben gynnwys mis
 cf.form.error.end.date.invalid.year=Mae’n rhaid i’r dyddiad dod i ben gynnwys blwyddyn
 cf.form.error.end.date.invalid.real-date=Mae’n rhaid i’r dyddiad i fod yn ddyddiad go iawn
-cf.form.error.end.date.empty.month = Yn eich cais am drafodion, nodwch hyd at ba fis yr hoffech eu cael
-cf.form.error.end.date.empty.year = Yn eich cais am drafodion, nodwch hyd at ba flwyddyn yr hoffech eu cael
-cf.form.error.end.date.empty.month.year = Yn eich cais am drafodion, nodwch hyd at ba fis a blwyddyn yr hoffech eu cael
-cf.form.error.end.date.invalid = Mae’n rhaid i’r dyddiad dod i ben fod yn ddyddiad go iawn
 
 cf.searchTransactions.form.error.required = Nodwch werth
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -268,16 +268,15 @@ cf.form.error.start.date.invalid.day=Mae’n rhaid i’r dyddiad o gynnwys diwrn
 cf.form.error.start.date.invalid.month=Mae’n rhaid i’r dyddiad i gynnwys mis
 cf.form.error.start.date.invalid.year=Mae’n rhaid i’r dyddiad o gynnwys blwyddyn
 cf.form.error.start.date.invalid.real-date=Mae’n rhaid i’r dyddiad o fod yn ddyddiad go iawn
-cf.form.error.end.date.invalid.day=Mae’n rhaid i’r dyddiad dod i ben gynnwys diwrnod
-cf.form.error.end.date.invalid.month=Mae’n rhaid i’r dyddiad dod i ben gynnwys mis
-cf.form.error.end.date.invalid.year=Mae’n rhaid i’r dyddiad dod i ben gynnwys blwyddyn
-cf.form.error.end.date.invalid.real-date=Mae’n rhaid i’r dyddiad i fod yn ddyddiad go iawn
-
 cf.form.error.start.date.empty.month = Yn eich cais am drafodion, nodwch o ba fis yr hoffech eu cael
 cf.form.error.start.date.empty.year = Yn eich cais am drafodion, nodwch o ba flwyddyn yr hoffech eu cael
 cf.form.error.start.date.empty.month.year = Yn eich cais am drafodion, nodwch o ba fis a blwyddyn yr hoffech eu cael
 cf.form.error.start.date.invalid = Mae’n rhaid i’r dyddiad dechrau fod yn ddyddiad go iawn
 
+cf.form.error.end.date.invalid.day=Mae’n rhaid i’r dyddiad dod i ben gynnwys diwrnod
+cf.form.error.end.date.invalid.month=Mae’n rhaid i’r dyddiad dod i ben gynnwys mis
+cf.form.error.end.date.invalid.year=Mae’n rhaid i’r dyddiad dod i ben gynnwys blwyddyn
+cf.form.error.end.date.invalid.real-date=Mae’n rhaid i’r dyddiad i fod yn ddyddiad go iawn
 cf.form.error.end.date.empty.month = Yn eich cais am drafodion, nodwch hyd at ba fis yr hoffech eu cael
 cf.form.error.end.date.empty.year = Yn eich cais am drafodion, nodwch hyd at ba flwyddyn yr hoffech eu cael
 cf.form.error.end.date.empty.month.year = Yn eich cais am drafodion, nodwch hyd at ba fis a blwyddyn yr hoffech eu cael

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -236,6 +236,7 @@ date.day=Diwrnod
 date.month=Mis
 date.year=Blwyddyn
 date.range = {0} i fis {1}.
+date.year.length.invalid = Mae’n rhaid i’r flwyddyn gynnwys 4 rhif
 
 cf.cash-account.requested.csv.filename=Trafodion_Cyfrif_Arian_Parod_{0}-{1}.CSV
 cf.cash-account.transactions.result.too.many.results=Mae gormod o ganlyniadau yn sgil eich chwiliad
@@ -271,6 +272,17 @@ cf.form.error.end.date.invalid.day=Mae’n rhaid i’r dyddiad dod i ben gynnwys
 cf.form.error.end.date.invalid.month=Mae’n rhaid i’r dyddiad dod i ben gynnwys mis
 cf.form.error.end.date.invalid.year=Mae’n rhaid i’r dyddiad dod i ben gynnwys blwyddyn
 cf.form.error.end.date.invalid.real-date=Mae’n rhaid i’r dyddiad i fod yn ddyddiad go iawn
+
+cf.form.error.start.date.empty.month = Yn eich cais am drafodion, nodwch o ba fis yr hoffech eu cael
+cf.form.error.start.date.empty.year = Yn eich cais am drafodion, nodwch o ba flwyddyn yr hoffech eu cael
+cf.form.error.start.date.empty.month.year = Yn eich cais am drafodion, nodwch o ba fis a blwyddyn yr hoffech eu cael
+cf.form.error.start.date.invalid = Mae’n rhaid i’r dyddiad dechrau fod yn ddyddiad go iawn
+
+cf.form.error.end.date.empty.month = Yn eich cais am drafodion, nodwch hyd at ba fis yr hoffech eu cael
+cf.form.error.end.date.empty.year = Yn eich cais am drafodion, nodwch hyd at ba flwyddyn yr hoffech eu cael
+cf.form.error.end.date.empty.month.year = Yn eich cais am drafodion, nodwch hyd at ba fis a blwyddyn yr hoffech eu cael
+cf.form.error.end.date.invalid = Mae’n rhaid i’r dyddiad dod i ben fod yn ddyddiad go iawn
+
 cf.searchTransactions.form.error.required = Nodwch werth
 
 error.summary.title = Mae problem wedi codi

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -252,6 +252,18 @@ cf.cash-account.requested.statements.available.text.pre=Your
 cf.cash-account.requested.statements.available.link.text=requested transactions
 cf.cash-account.requested.statements.available.text.post=are now available
 
+# Request cash Transactions
+cf.cash-account.transactions.request.start.date.empty.month = Enter the month you want to request transactions from
+cf.cash-account.transactions.request.start.date.empty.year = Enter the year you want to request transactions from
+cf.cash-account.transactions.request.start.date.empty.month.year = Enter the month and year you want to request transactions from
+cf.cash-account.transactions.request.start.date.invalid = Start date must be a real date
+
+cf.cash-account.transactions.request.end.date.empty.month = Enter the month you want to request transactions to
+cf.cash-account.transactions.request.end.date.empty.year = Enter the year you want to request transactions to
+cf.cash-account.transactions.request.end.date.empty.month.year = Enter the month and year you want to request transactions to
+cf.cash-account.transactions.request.end.date.invalid = End date must be a real date
+
+# Date form error
 cf.form.error.start.date-too-far-in-past=The from date cannot be older than 6 years from now.
 cf.form.error.end.date-too-far-in-past=The to date cannot be older than 6 years from now.
 cf.form.error.year.length = Year must include 4 numbers
@@ -268,19 +280,11 @@ cf.form.error.start.date.invalid.day=The from date must include a day
 cf.form.error.start.date.invalid.month=The from date must include a month
 cf.form.error.start.date.invalid.year=The from date must include a year
 cf.form.error.start.date.invalid.real-date=The from date must be a real date
-cf.form.error.start.date.empty.month = Enter the month you want to request transactions from
-cf.form.error.start.date.empty.year = Enter the year you want to request transactions from
-cf.form.error.start.date.empty.month.year = Enter the month and year you want to request transactions from
-cf.form.error.start.date.invalid = Start date must be a real date
 
 cf.form.error.end.date.invalid.day=The end date must include a day
 cf.form.error.end.date.invalid.month=The end date must include a month
 cf.form.error.end.date.invalid.year=The end date must include a year
 cf.form.error.end.date.invalid.real-date=The to date must be a real date
-cf.form.error.end.date.empty.month = Enter the month you want to request transactions to
-cf.form.error.end.date.empty.year = Enter the year you want to request transactions to
-cf.form.error.end.date.empty.month.year = Enter the month and year you want to request transactions to
-cf.form.error.end.date.invalid = End date must be a real date
 
 cf.searchTransactions.form.error.required = Please enter a value
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -268,17 +268,15 @@ cf.form.error.start.date.invalid.day=The from date must include a day
 cf.form.error.start.date.invalid.month=The from date must include a month
 cf.form.error.start.date.invalid.year=The from date must include a year
 cf.form.error.start.date.invalid.real-date=The from date must be a real date
-
-cf.form.error.end.date.invalid.day=The end date must include a day
-cf.form.error.end.date.invalid.month=The end date must include a month
-cf.form.error.end.date.invalid.year=The end date must include a year
-cf.form.error.end.date.invalid.real-date=The to date must be a real date
-
 cf.form.error.start.date.empty.month = Enter the month you want to request transactions from
 cf.form.error.start.date.empty.year = Enter the year you want to request transactions from
 cf.form.error.start.date.empty.month.year = Enter the month and year you want to request transactions from
 cf.form.error.start.date.invalid = Start date must be a real date
 
+cf.form.error.end.date.invalid.day=The end date must include a day
+cf.form.error.end.date.invalid.month=The end date must include a month
+cf.form.error.end.date.invalid.year=The end date must include a year
+cf.form.error.end.date.invalid.real-date=The to date must be a real date
 cf.form.error.end.date.empty.month = Enter the month you want to request transactions to
 cf.form.error.end.date.empty.year = Enter the year you want to request transactions to
 cf.form.error.end.date.empty.month.year = Enter the month and year you want to request transactions to

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -236,6 +236,7 @@ date.day=Day
 date.month=Month
 date.year=Year
 date.range = {0} to {1}.
+date.year.length.invalid = Year must include 4 numbers
 
 cf.cash-account.requested.csv.filename=Cash_Account_Transactions_{0}-{1}.CSV
 cf.cash-account.transactions.result.too.many.results=Your search returned too many results
@@ -267,10 +268,21 @@ cf.form.error.start.date.invalid.day=The from date must include a day
 cf.form.error.start.date.invalid.month=The from date must include a month
 cf.form.error.start.date.invalid.year=The from date must include a year
 cf.form.error.start.date.invalid.real-date=The from date must be a real date
+
 cf.form.error.end.date.invalid.day=The end date must include a day
 cf.form.error.end.date.invalid.month=The end date must include a month
 cf.form.error.end.date.invalid.year=The end date must include a year
 cf.form.error.end.date.invalid.real-date=The to date must be a real date
+
+cf.form.error.start.date.empty.month = Enter the month you want to request transactions from
+cf.form.error.start.date.empty.year = Enter the year you want to request transactions from
+cf.form.error.start.date.empty.month.year = Enter the month and year you want to request transactions from
+cf.form.error.start.date.invalid = Start date must be a real date
+
+cf.form.error.end.date.empty.month = Enter the month you want to request transactions to
+cf.form.error.end.date.empty.year = Enter the year you want to request transactions to
+cf.form.error.end.date.empty.month.year = Enter the month and year you want to request transactions to
+cf.form.error.end.date.invalid = End date must be a real date
 
 cf.searchTransactions.form.error.required = Please enter a value
 

--- a/test/forms/SelectTransactionsFormProviderSpec.scala
+++ b/test/forms/SelectTransactionsFormProviderSpec.scala
@@ -27,46 +27,52 @@ class SelectTransactionsFormProviderSpec extends SpecBase {
 
   "apply" must {
 
-    "populate RequestTransactionRequestPage form correctly (or with correct error) for input start date" when {
+    "populate form correctly (or with correct error) for input start date" when {
 
-      "the month of start date is blank " in new SetUp {
-        val startDate: Map[String, String] =
-          populateFormValueMap(startKey, emptyString, year2021AsString)
+      "the month value of start date is blank" in new SetUp {
+        val startDate: Map[String, String] = populateFormValueMap(startKey, emptyString, year2021AsString)
 
-        val validEndDate: Map[String, String] =
-          populateFormValueMap(endKey, month10AsString, year2021AsString)
+        val validEndDate: Map[String, String] = populateFormValueMap(endKey, month10AsString, year2021AsString)
 
         val formData: Map[String, String] = startDate ++ validEndDate
 
-        val expectedErrors: Seq[FormError] = error("start.month", invalidMsgStartKey)
+        val expectedErrors: Seq[FormError] = error("start.month", emptyMonthStartDateErrorKey)
 
         checkForError(form, formData, expectedErrors)
       }
 
-      "the year of start date is blank " in new SetUp {
-        val startDate: Map[String, String] =
-          populateFormValueMap(startKey, month10AsString, emptyString)
+      "the year value of start date is blank" in new SetUp {
+        val startDate: Map[String, String] = populateFormValueMap(startKey, month10AsString, emptyString)
 
-        val validEndDate: Map[String, String] =
-          populateFormValueMap(endKey, month10AsString, year2021AsString)
+        val validEndDate: Map[String, String] = populateFormValueMap(endKey, month10AsString, year2021AsString)
 
         val formData: Map[String, String] = startDate ++ validEndDate
 
-        val expectedErrors: Seq[FormError] = error("start.year", invalidMsgStartKey)
+        val expectedErrors: Seq[FormError] = error("start.year", emptyYearStartDateErrorKey)
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "the month and year values of start date are empty" in new SetUp {
+        val startDate: Map[String, String] = populateFormValueMap(startKey, emptyString, emptyString)
+
+        val validEndDate: Map[String, String] = populateFormValueMap(endKey, month10AsString, year2021AsString)
+
+        val formData: Map[String, String] = startDate ++ validEndDate
+
+        val expectedErrors: Seq[FormError] = error("start.year", emptyMonthAndYearStartDateErrorKey)
 
         checkForError(form, formData, expectedErrors)
       }
 
       "the month value is invalid for the start date" in new SetUp {
-        val startDate: Map[String, String] =
-          populateFormValueMap(startKey, month14AsString, year2021AsString)
+        val startDate: Map[String, String] = populateFormValueMap(startKey, month14AsString, year2021AsString)
 
-        val validEndDate: Map[String, String] =
-          populateFormValueMap(endKey, month10AsString, year2021AsString)
+        val validEndDate: Map[String, String] = populateFormValueMap(endKey, month10AsString, year2021AsString)
 
         val formData: Map[String, String] = startDate ++ validEndDate
 
-        val expectedErrors: Seq[FormError] = error("start.month", invalidDateMsgStartKey)
+        val expectedErrors: Seq[FormError] = error("start.month", invalidStartDateKey)
 
         checkForError(form, formData, expectedErrors)
       }
@@ -74,15 +80,27 @@ class SelectTransactionsFormProviderSpec extends SpecBase {
       "the year value is invalid for the start date" in new SetUp {
         val invalidYearValue = "-"
 
-        val startDate: Map[String, String] =
-          populateFormValueMap(startKey, month10AsString, invalidYearValue)
+        val startDate: Map[String, String] = populateFormValueMap(startKey, month10AsString, invalidYearValue)
 
-        val validEndDate: Map[String, String] =
-          populateFormValueMap(endKey, month10AsString, year2021AsString)
+        val validEndDate: Map[String, String] = populateFormValueMap(endKey, month10AsString, year2021AsString)
 
         val formData: Map[String, String] = startDate ++ validEndDate
 
-        val expectedErrors: Seq[FormError] = error("start.year", invalidMsgStartKey)
+        val expectedErrors: Seq[FormError] = error("start.year", invalidStartDateKey)
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "the year length is less than 4 digits" in new SetUp {
+        val yearWithInvalidLength = "202"
+
+        val startDate: Map[String, String] = populateFormValueMap(startKey, month10AsString, yearWithInvalidLength)
+
+        val validEndDate: Map[String, String] = populateFormValueMap(endKey, month10AsString, year2021AsString)
+
+        val formData: Map[String, String] = startDate ++ validEndDate
+
+        val expectedErrors: Seq[FormError] = error(startKey, invalidYearLengthKey)
 
         checkForError(form, formData, expectedErrors)
       }
@@ -90,15 +108,13 @@ class SelectTransactionsFormProviderSpec extends SpecBase {
       "start date has invalid length of the year" in new SetUp {
         val yearWithInvalidLength = "20211"
 
-        val startDate: Map[String, String] =
-          populateFormValueMap(startKey, month10AsString, yearWithInvalidLength)
+        val startDate: Map[String, String] = populateFormValueMap(startKey, month10AsString, yearWithInvalidLength)
 
-        val validEndDate: Map[String, String] =
-          populateFormValueMap(endKey, month10AsString, year2021AsString)
+        val validEndDate: Map[String, String] = populateFormValueMap(endKey, month10AsString, year2021AsString)
 
         val formData: Map[String, String] = startDate ++ validEndDate
 
-        val expectedErrors: Seq[FormError] = error(startKey, "cf.form.error.year.length")
+        val expectedErrors: Seq[FormError] = error(startKey, invalidYearLengthKey)
 
         checkForError(form, formData, expectedErrors)
       }
@@ -107,8 +123,7 @@ class SelectTransactionsFormProviderSpec extends SpecBase {
         val startDate: Map[String, String] =
           populateFormValueMap(startKey, month10AsString, (etmpStatementYear - 1).toString)
 
-        val validEndDate: Map[String, String] =
-          populateFormValueMap(endKey, month10AsString, year2021AsString)
+        val validEndDate: Map[String, String] = populateFormValueMap(endKey, month10AsString, year2021AsString)
 
         val formData: Map[String, String] = startDate ++ validEndDate
 
@@ -127,43 +142,50 @@ class SelectTransactionsFormProviderSpec extends SpecBase {
       }
 
       "the month of end date is blank" in new SetUp {
-        val validStartDate: Map[String, String] =
-          populateFormValueMap(startKey, month10AsString, year2021AsString)
+        val validStartDate: Map[String, String] = populateFormValueMap(startKey, month10AsString, year2021AsString)
 
-        val endDate: Map[String, String] =
-          populateFormValueMap(endKey, emptyString, year2021AsString)
+        val endDate: Map[String, String] = populateFormValueMap(endKey, emptyString, year2021AsString)
 
         val formData: Map[String, String] = validStartDate ++ endDate
 
-        val expectedErrors: Seq[FormError] = error("end.month", invalidMsgEndKey)
+        val expectedErrors: Seq[FormError] = error("end.month", emptyMonthEndDateErrorKey)
 
         checkForError(form, formData, expectedErrors)
       }
 
       "the year of end date is blank " in new SetUp {
-        val validStartDate: Map[String, String] =
-          populateFormValueMap(startKey, month10AsString, year2021AsString)
+        val validStartDate: Map[String, String] = populateFormValueMap(startKey, month10AsString, year2021AsString)
 
-        val endDate: Map[String, String] =
-          populateFormValueMap(endKey, month10AsString, emptyString)
+        val endDate: Map[String, String] = populateFormValueMap(endKey, month10AsString, emptyString)
 
         val formData: Map[String, String] = validStartDate ++ endDate
 
-        val expectedErrors: Seq[FormError] = error("end.year", invalidMsgEndKey)
+        val expectedErrors: Seq[FormError] = error("end.year", emptyYearEndDateErrorKey)
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "the month and year of end date are empty" in new SetUp {
+        val startDate: Map[String, String] = populateFormValueMap(startKey, month10AsString, year2021AsString)
+
+        val validEndDate: Map[String, String] = populateFormValueMap(endKey, emptyString, emptyString)
+
+        val formData: Map[String, String] = startDate ++ validEndDate
+
+        val expectedErrors: Seq[FormError] = error("end.year", emptyMonthAndYearEndDateErrorKey)
 
         checkForError(form, formData, expectedErrors)
       }
 
       "the month value is invalid for the end date" in new SetUp {
-        val validStartDate: Map[String, String] =
-          populateFormValueMap(startKey, month10AsString, year2021AsString)
+        val validStartDate: Map[String, String] = populateFormValueMap(startKey, month10AsString, year2021AsString)
 
         val endDate: Map[String, String] =
           Map(s"$endKey.month" -> month14AsString, s"$endKey.year" -> year2021AsString)
 
         val formData: Map[String, String] = validStartDate ++ endDate
 
-        val expectedErrors: Seq[FormError] = Seq(FormError("end.month", invalidDateMsgEndKey))
+        val expectedErrors: Seq[FormError] = Seq(FormError("end.month", invalidEndDateKey))
 
         checkForError(form, formData, expectedErrors)
       }
@@ -171,25 +193,21 @@ class SelectTransactionsFormProviderSpec extends SpecBase {
       "the year value is invalid for the end date" in new SetUp {
         val invalidYearValue = "-"
 
-        val validStartDate: Map[String, String] =
-          populateFormValueMap(startKey, month10AsString, year2021AsString)
+        val validStartDate: Map[String, String] = populateFormValueMap(startKey, month10AsString, year2021AsString)
 
-        val endDate: Map[String, String] =
-          populateFormValueMap(endKey, month14AsString, invalidYearValue)
+        val endDate: Map[String, String] = populateFormValueMap(endKey, month14AsString, invalidYearValue)
 
         val formData: Map[String, String] = validStartDate ++ endDate
 
-        val expectedErrors: Seq[FormError] = error("end.year", invalidMsgEndKey)
+        val expectedErrors: Seq[FormError] = error("end.year", invalidEndDateKey)
 
         checkForError(form, formData, expectedErrors)
       }
 
       "end date is in future" in new SetUp {
-        val validStartDate: Map[String, String] =
-          populateFormValueMap(startKey, month10AsString, year2021AsString)
+        val validStartDate: Map[String, String] = populateFormValueMap(startKey, month10AsString, year2021AsString)
 
-        val endDate: Map[String, String] =
-          populateFormValueMap(endKey, month10AsString, futureYear.toString)
+        val endDate: Map[String, String] = populateFormValueMap(endKey, month10AsString, futureYear.toString)
 
         val formData: Map[String, String] = validStartDate ++ endDate
 
@@ -201,15 +219,28 @@ class SelectTransactionsFormProviderSpec extends SpecBase {
       "end date has invalid length of the year" in new SetUp {
         val yearWithInvalidLength = "20112"
 
-        val validStartDate: Map[String, String] =
-          populateFormValueMap(startKey, month10AsString, year2021AsString)
+        val validStartDate: Map[String, String] = populateFormValueMap(startKey, month10AsString, year2021AsString)
+
+        val endDate: Map[String, String] = populateFormValueMap(endKey, month10AsString, yearWithInvalidLength)
+
+        val formData: Map[String, String] = validStartDate ++ endDate
+
+        val expectedErrors: Seq[FormError] = error(endKey, invalidYearLengthKey)
+
+        checkForError(form, formData, expectedErrors)
+      }
+
+      "the year length is less than 4 digits" in new SetUp {
+        val yearWithInvalidLength = "202"
+
+        val startDate: Map[String, String] = populateFormValueMap(startKey, month10AsString, year2021AsString)
 
         val endDate: Map[String, String] =
           populateFormValueMap(endKey, month10AsString, yearWithInvalidLength)
 
-        val formData: Map[String, String] = validStartDate ++ endDate
+        val formData: Map[String, String] = startDate ++ endDate
 
-        val expectedErrors: Seq[FormError] = error(endKey, "cf.form.error.year.length")
+        val expectedErrors: Seq[FormError] = error(endKey, invalidYearLengthKey)
 
         checkForError(form, formData, expectedErrors)
       }
@@ -253,6 +284,18 @@ class SelectTransactionsFormProviderSpec extends SpecBase {
 
     val invalidMsgStartKey = "cf.form.error.start.date-number-invalid"
     val invalidDateMsgStartKey = "cf.form.error.start.date.invalid.real-date"
+
+    val emptyMonthStartDateErrorKey = "cf.form.error.start.date.empty.month"
+    val emptyYearStartDateErrorKey = "cf.form.error.start.date.empty.year"
+    val emptyMonthAndYearStartDateErrorKey = "cf.form.error.start.date.empty.month.year"
+    val invalidStartDateKey = "cf.form.error.start.date.invalid"
+
+    val emptyMonthEndDateErrorKey = "cf.form.error.end.date.empty.month"
+    val emptyYearEndDateErrorKey = "cf.form.error.end.date.empty.year"
+    val emptyMonthAndYearEndDateErrorKey = "cf.form.error.end.date.empty.month.year"
+    val invalidEndDateKey = "cf.form.error.end.date.invalid"
+
+    val invalidYearLengthKey = "date.year.length.invalid"
 
     val invalidMsgEndKey = "cf.form.error.end.date-number-invalid"
     val invalidDateMsgEndKey = "cf.form.error.end.date.invalid.real-date"

--- a/test/forms/SelectTransactionsFormProviderSpec.scala
+++ b/test/forms/SelectTransactionsFormProviderSpec.scala
@@ -60,7 +60,7 @@ class SelectTransactionsFormProviderSpec extends SpecBase {
 
         val formData: Map[String, String] = startDate ++ validEndDate
 
-        val expectedErrors: Seq[FormError] = error("start.year", emptyMonthAndYearStartDateErrorKey)
+        val expectedErrors: Seq[FormError] = error("start.month", emptyMonthAndYearStartDateErrorKey)
 
         checkForError(form, formData, expectedErrors)
       }
@@ -172,7 +172,7 @@ class SelectTransactionsFormProviderSpec extends SpecBase {
 
         val formData: Map[String, String] = startDate ++ validEndDate
 
-        val expectedErrors: Seq[FormError] = error("end.year", emptyMonthAndYearEndDateErrorKey)
+        val expectedErrors: Seq[FormError] = error("end.month", emptyMonthAndYearEndDateErrorKey)
 
         checkForError(form, formData, expectedErrors)
       }

--- a/test/forms/SelectTransactionsFormProviderSpec.scala
+++ b/test/forms/SelectTransactionsFormProviderSpec.scala
@@ -282,9 +282,6 @@ class SelectTransactionsFormProviderSpec extends SpecBase {
     val startKey = "start"
     val endKey = "end"
 
-    val invalidMsgStartKey = "cf.form.error.start.date-number-invalid"
-    val invalidDateMsgStartKey = "cf.form.error.start.date.invalid.real-date"
-
     val emptyMonthStartDateErrorKey = "cf.form.error.start.date.empty.month"
     val emptyYearStartDateErrorKey = "cf.form.error.start.date.empty.year"
     val emptyMonthAndYearStartDateErrorKey = "cf.form.error.start.date.empty.month.year"

--- a/test/forms/SelectTransactionsFormProviderSpec.scala
+++ b/test/forms/SelectTransactionsFormProviderSpec.scala
@@ -294,9 +294,6 @@ class SelectTransactionsFormProviderSpec extends SpecBase {
 
     val invalidYearLengthKey = "date.year.length.invalid"
 
-    val invalidMsgEndKey = "cf.form.error.end.date-number-invalid"
-    val invalidDateMsgEndKey = "cf.form.error.end.date.invalid.real-date"
-
     lazy val completeValidDates: Map[String, String] =
       populateFormValueMap(startKey, month10AsString, year2021AsString) ++
         Map(s"$endKey.month" -> month10AsString, s"$endKey.year" -> year2021AsString)

--- a/test/forms/SelectTransactionsFormProviderSpec.scala
+++ b/test/forms/SelectTransactionsFormProviderSpec.scala
@@ -282,15 +282,15 @@ class SelectTransactionsFormProviderSpec extends SpecBase {
     val startKey = "start"
     val endKey = "end"
 
-    val emptyMonthStartDateErrorKey = "cf.form.error.start.date.empty.month"
-    val emptyYearStartDateErrorKey = "cf.form.error.start.date.empty.year"
-    val emptyMonthAndYearStartDateErrorKey = "cf.form.error.start.date.empty.month.year"
-    val invalidStartDateKey = "cf.form.error.start.date.invalid"
+    val emptyMonthStartDateErrorKey = "cf.cash-account.transactions.request.start.date.empty.month"
+    val emptyYearStartDateErrorKey = "cf.cash-account.transactions.request.start.date.empty.year"
+    val emptyMonthAndYearStartDateErrorKey = "cf.cash-account.transactions.request.start.date.empty.month.year"
+    val invalidStartDateKey = "cf.cash-account.transactions.request.start.date.invalid"
 
-    val emptyMonthEndDateErrorKey = "cf.form.error.end.date.empty.month"
-    val emptyYearEndDateErrorKey = "cf.form.error.end.date.empty.year"
-    val emptyMonthAndYearEndDateErrorKey = "cf.form.error.end.date.empty.month.year"
-    val invalidEndDateKey = "cf.form.error.end.date.invalid"
+    val emptyMonthEndDateErrorKey = "cf.cash-account.transactions.request.end.date.empty.month"
+    val emptyYearEndDateErrorKey = "cf.cash-account.transactions.request.end.date.empty.year"
+    val emptyMonthAndYearEndDateErrorKey = "cf.cash-account.transactions.request.end.date.empty.month.year"
+    val invalidEndDateKey = "cf.cash-account.transactions.request.end.date.invalid"
 
     val invalidYearLengthKey = "date.year.length.invalid"
 

--- a/test/forms/mappings/SelectLocalDateFormatterSpec.scala
+++ b/test/forms/mappings/SelectLocalDateFormatterSpec.scala
@@ -25,8 +25,8 @@ import java.time.LocalDate
 class SelectLocalDateFormatterSpec extends SpecBase {
 
   "bind" must {
-    "return the correct LocalDate when the supplied data is valid" in new SetUp {
 
+    "return the correct LocalDate when the supplied data is valid" in new SetUp {
       val localYear = 2022
       val localMonth = 10
 
@@ -87,7 +87,7 @@ class SelectLocalDateFormatterSpec extends SpecBase {
 
     "return key.month as updated key when month value is empty" in new SetUp {
 
-      val formDataWithEmptyMonth: Map[String, String] = Map(s"$key.month" -> "", s"$key.year" -> "2021")
+      val formDataWithEmptyMonth: Map[String, String] = Map(s"$key.month" -> emptyString, s"$key.year" -> "2021")
 
       localDateFormatter.formErrorKeysInCaseOfEmptyOrNonNumericValues(
         key,
@@ -97,7 +97,7 @@ class SelectLocalDateFormatterSpec extends SpecBase {
 
     "return key.year as updated key when year value is empty" in new SetUp {
 
-      val formDataWithEmptyYear: Map[String, String] = Map(s"$key.month" -> "10", s"$key.year" -> "")
+      val formDataWithEmptyYear: Map[String, String] = Map(s"$key.month" -> "10", s"$key.year" -> emptyString)
 
       localDateFormatter.formErrorKeysInCaseOfEmptyOrNonNumericValues(
         key,
@@ -148,7 +148,6 @@ class SelectLocalDateFormatterSpec extends SpecBase {
     val day: Int = 1
 
     val key = "start"
-    val invalidMsgKey = "cf.form.error.start.date-number-invalid"
     val emptyMonthAndYearMsgKey = "cf.form.error.start.date.empty.month.year"
     val emptyMonthMsgKey = "cf.form.error.start.date.empty.month"
     val emptyYearMsgKey = "cf.form.error.start.date.empty.year"
@@ -158,10 +157,10 @@ class SelectLocalDateFormatterSpec extends SpecBase {
       "start.day" -> day.toString, "start.month" -> "10", "start.year" -> "2022")
 
     val bindDataEmptyDate: Map[String, String] = Map(
-      "start.day" -> day.toString, "start.month" -> "", "start.year" -> "")
+      "start.day" -> day.toString, "start.month" -> emptyString, "start.year" -> emptyString)
 
     val localDateFormatter = new SelectLocalDateFormatter(
-      invalidMsgKey,
+      emptyMonthAndYearMsgKey,
       emptyMonthMsgKey,
       emptyYearMsgKey,
       invalidDateMsgKey,
@@ -179,7 +178,7 @@ class SelectLocalDateFormatterSpec extends SpecBase {
     )
 
     val localDateFormatterWithLastDay = new SelectLocalDateFormatter(
-      invalidMsgKey,
+      emptyMonthAndYearMsgKey,
       emptyMonthMsgKey,
       emptyYearMsgKey,
       invalidDateMsgKey,
@@ -191,10 +190,10 @@ class SelectLocalDateFormatterSpec extends SpecBase {
       Map("start.day" -> "1", "start.month" -> emptyString, "start.year" -> emptyString)
 
     val bindDataDateWithEmptyMonth: Map[String, String] =
-      Map("start.day" -> "1", "start.month" -> "", "start.year" -> "2022")
+      Map("start.day" -> "1", "start.month" -> emptyString, "start.year" -> "2022")
 
     val bindDataDateWithEmptyYear: Map[String, String] =
-      Map("start.day" -> "1", "start.month" -> "10", "start.year" -> "")
+      Map("start.day" -> "1", "start.month" -> "10", "start.year" -> emptyString)
 
     val bindDataInValidDate: Map[String, String] =
       Map("start.day" -> "1", "start.month" -> "14", "start.year" -> "2023")

--- a/test/forms/mappings/SelectLocalDateFormatterSpec.scala
+++ b/test/forms/mappings/SelectLocalDateFormatterSpec.scala
@@ -35,14 +35,19 @@ class SelectLocalDateFormatterSpec extends SpecBase {
       )
     }
 
+    "return the correct FormError with key when the supplied data has empty month and year" in new SetUp {
+      localDateFormatterWithEmptyMonthAndYear.bind(key, bindDataDateWithEmptyMonthAndYear) shouldBe
+        Left(Seq(FormError("start.month", List(emptyMonthAndYearMsgKey), List())))
+    }
+
     "return the correct FormError with keys when the supplied data is empty month" in new SetUp {
       localDateFormatter.bind(key, bindDataDateWithEmptyMonth) shouldBe
-        Left(Seq(FormError("start.month", List(invalidMsgKey), List())))
+        Left(Seq(FormError("start.month", List(monthMsgKey), List())))
     }
 
     "return the correct FormError with keys when the supplied data empty year" in new SetUp {
       localDateFormatter.bind(key, bindDataDateWithEmptyYear) shouldBe
-        Left(Seq(FormError("start.year", List(invalidMsgKey), List())))
+        Left(Seq(FormError("start.year", List(yearMsgKey), List())))
     }
 
     "return the correct FormError with keys when the supplied data is invalid month" in new SetUp {
@@ -144,6 +149,7 @@ class SelectLocalDateFormatterSpec extends SpecBase {
 
     val key = "start"
     val invalidMsgKey = "cf.form.error.start.date-number-invalid"
+    val emptyMonthAndYearMsgKey = "cf.form.error.start.date.empty.month.year"
     val monthMsgKey = "cf.form.error.start.date.invalid.month"
     val yearMsgKey = "cf.form.error.start.date.invalid.year"
     val invalidRealDateMsgKey = "cf.form.error.start.date.invalid.real-date"
@@ -163,6 +169,15 @@ class SelectLocalDateFormatterSpec extends SpecBase {
       useLastDayOfMonth = false
     )
 
+    val localDateFormatterWithEmptyMonthAndYear = new SelectLocalDateFormatter(
+      emptyMonthAndYearMsgKey,
+      monthMsgKey,
+      yearMsgKey,
+      invalidRealDateMsgKey,
+      Seq(),
+      useLastDayOfMonth = false
+    )
+
     val localDateFormatterWithLastDay = new SelectLocalDateFormatter(
       invalidMsgKey,
       monthMsgKey,
@@ -171,6 +186,9 @@ class SelectLocalDateFormatterSpec extends SpecBase {
       Seq(),
       useLastDayOfMonth = true
     )
+
+    val bindDataDateWithEmptyMonthAndYear: Map[String, String] =
+      Map("start.day" -> "1", "start.month" -> emptyString, "start.year" -> emptyString)
 
     val bindDataDateWithEmptyMonth: Map[String, String] =
       Map("start.day" -> "1", "start.month" -> "", "start.year" -> "2022")

--- a/test/forms/mappings/SelectLocalDateFormatterSpec.scala
+++ b/test/forms/mappings/SelectLocalDateFormatterSpec.scala
@@ -63,6 +63,14 @@ class SelectLocalDateFormatterSpec extends SpecBase {
 
   }
 
+  "unbind" must {
+
+    "return the correct plain data" in new SetUp {
+      localDateFormatter.unbind(
+        key, LocalDate.of(year, month, day)) mustBe Map(s"$key.month" -> month.toString, s"$key.year" -> year.toString)
+    }
+  }
+
   "updateFormErrorKeys" must {
     "append the month in the existing key when month is incorrect" in new SetUp {
 

--- a/test/forms/mappings/SelectLocalDateFormatterSpec.scala
+++ b/test/forms/mappings/SelectLocalDateFormatterSpec.scala
@@ -42,23 +42,23 @@ class SelectLocalDateFormatterSpec extends SpecBase {
 
     "return the correct FormError with keys when the supplied data is empty month" in new SetUp {
       localDateFormatter.bind(key, bindDataDateWithEmptyMonth) shouldBe
-        Left(Seq(FormError("start.month", List(monthMsgKey), List())))
+        Left(Seq(FormError("start.month", List(emptyMonthMsgKey), List())))
     }
 
     "return the correct FormError with keys when the supplied data empty year" in new SetUp {
       localDateFormatter.bind(key, bindDataDateWithEmptyYear) shouldBe
-        Left(Seq(FormError("start.year", List(yearMsgKey), List())))
+        Left(Seq(FormError("start.year", List(emptyYearMsgKey), List())))
     }
 
     "return the correct FormError with keys when the supplied data is invalid month" in new SetUp {
 
       localDateFormatter.bind(key, bindDataInValidMonth) shouldBe
-        Left(Seq(FormError("start.month", List(invalidRealDateMsgKey), List())))
+        Left(Seq(FormError("start.month", List(invalidDateMsgKey), List())))
     }
 
     "return the correct FormError with keys when the supplied data is invalid year" in new SetUp {
       localDateFormatter.bind(key, bindDataInValidYear) shouldBe
-        Left(Seq(FormError("start.year", List(invalidRealDateMsgKey), List())))
+        Left(Seq(FormError("start.year", List(invalidDateMsgKey), List())))
     }
 
   }
@@ -150,9 +150,9 @@ class SelectLocalDateFormatterSpec extends SpecBase {
     val key = "start"
     val invalidMsgKey = "cf.form.error.start.date-number-invalid"
     val emptyMonthAndYearMsgKey = "cf.form.error.start.date.empty.month.year"
-    val monthMsgKey = "cf.form.error.start.date.invalid.month"
-    val yearMsgKey = "cf.form.error.start.date.invalid.year"
-    val invalidRealDateMsgKey = "cf.form.error.start.date.invalid.real-date"
+    val emptyMonthMsgKey = "cf.form.error.start.date.empty.month"
+    val emptyYearMsgKey = "cf.form.error.start.date.empty.year"
+    val invalidDateMsgKey = "cf.form.error.start.date.invalid"
 
     val bindDataValid: Map[String, String] = Map(
       "start.day" -> day.toString, "start.month" -> "10", "start.year" -> "2022")
@@ -162,27 +162,27 @@ class SelectLocalDateFormatterSpec extends SpecBase {
 
     val localDateFormatter = new SelectLocalDateFormatter(
       invalidMsgKey,
-      monthMsgKey,
-      yearMsgKey,
-      invalidRealDateMsgKey,
+      emptyMonthMsgKey,
+      emptyYearMsgKey,
+      invalidDateMsgKey,
       Seq(),
       useLastDayOfMonth = false
     )
 
     val localDateFormatterWithEmptyMonthAndYear = new SelectLocalDateFormatter(
       emptyMonthAndYearMsgKey,
-      monthMsgKey,
-      yearMsgKey,
-      invalidRealDateMsgKey,
+      emptyMonthMsgKey,
+      emptyYearMsgKey,
+      invalidDateMsgKey,
       Seq(),
       useLastDayOfMonth = false
     )
 
     val localDateFormatterWithLastDay = new SelectLocalDateFormatter(
       invalidMsgKey,
-      monthMsgKey,
-      yearMsgKey,
-      invalidRealDateMsgKey,
+      emptyMonthMsgKey,
+      emptyYearMsgKey,
+      invalidDateMsgKey,
       Seq(),
       useLastDayOfMonth = true
     )

--- a/test/forms/mappings/SelectLocalDateFormatterSpec.scala
+++ b/test/forms/mappings/SelectLocalDateFormatterSpec.scala
@@ -51,7 +51,6 @@ class SelectLocalDateFormatterSpec extends SpecBase {
     }
 
     "return the correct FormError with keys when the supplied data is invalid month" in new SetUp {
-
       localDateFormatter.bind(key, bindDataInValidMonth) shouldBe
         Left(Seq(FormError("start.month", List(invalidDateMsgKey), List())))
     }
@@ -149,7 +148,6 @@ class SelectLocalDateFormatterSpec extends SpecBase {
   trait SetUp {
 
     val year: Int = 2023
-    val year1: Int = -1
     val year2: Int = -2022
     val month: Int = 12
     val month1: Int = 14
@@ -163,9 +161,6 @@ class SelectLocalDateFormatterSpec extends SpecBase {
 
     val bindDataValid: Map[String, String] = Map(
       "start.day" -> day.toString, "start.month" -> "10", "start.year" -> "2022")
-
-    val bindDataEmptyDate: Map[String, String] = Map(
-      "start.day" -> day.toString, "start.month" -> emptyString, "start.year" -> emptyString)
 
     val localDateFormatter = new SelectLocalDateFormatter(
       emptyMonthAndYearMsgKey,
@@ -202,9 +197,6 @@ class SelectLocalDateFormatterSpec extends SpecBase {
 
     val bindDataDateWithEmptyYear: Map[String, String] =
       Map("start.day" -> "1", "start.month" -> "10", "start.year" -> emptyString)
-
-    val bindDataInValidDate: Map[String, String] =
-      Map("start.day" -> "1", "start.month" -> "14", "start.year" -> "2023")
 
     val bindDataInValidMonth: Map[String, String] =
       Map("start.day" -> "1", "start.month" -> "14", "start.year" -> "2022")

--- a/test/forms/mappings/SelectLocalDateFormatterSpec.scala
+++ b/test/forms/mappings/SelectLocalDateFormatterSpec.scala
@@ -156,10 +156,10 @@ class SelectLocalDateFormatterSpec extends SpecBase {
     val day: Int = 1
 
     val key = "start"
-    val emptyMonthAndYearMsgKey = "cf.form.error.start.date.empty.month.year"
-    val emptyMonthMsgKey = "cf.form.error.start.date.empty.month"
-    val emptyYearMsgKey = "cf.form.error.start.date.empty.year"
-    val invalidDateMsgKey = "cf.form.error.start.date.invalid"
+    val emptyMonthAndYearMsgKey = "cf.cash-account.transactions.request.start.date.empty.month.year"
+    val emptyMonthMsgKey = "cf.cash-account.transactions.request.start.date.empty.month"
+    val emptyYearMsgKey = "cf.cash-account.transactions.request.start.date.empty.year"
+    val invalidDateMsgKey = "cf.cash-account.transactions.request.start.date.invalid"
 
     val bindDataValid: Map[String, String] = Map(
       "start.day" -> day.toString, "start.month" -> "10", "start.year" -> "2022")

--- a/test/forms/mappings/SelectLocalDateFormatterSpec.scala
+++ b/test/forms/mappings/SelectLocalDateFormatterSpec.scala
@@ -58,7 +58,7 @@ class SelectLocalDateFormatterSpec extends SpecBase {
 
     "return the correct FormError with keys when the supplied data is invalid year" in new SetUp {
       localDateFormatter.bind(key, bindDataInValidYear) shouldBe
-        Left(Seq(FormError("start.year", List(invalidMsgKey), List())))
+        Left(Seq(FormError("start.year", List(invalidRealDateMsgKey), List())))
     }
 
   }

--- a/test/views/ConfirmationPageSpec.scala
+++ b/test/views/ConfirmationPageSpec.scala
@@ -50,7 +50,7 @@ class ConfirmationPageSpec extends SpecBase with ViewTestHelper {
       }
 
       "body text email is correct and email address is present" in new Setup {
-        view.html.contains(messages(app)("cf.cash-account.transactions.confirmation.email", email))
+        view.html.contains(messages("cf.cash-account.transactions.confirmation.email", email))
       }
 
       "email address is not present" in new Setup {


### PR DESCRIPTION
Description - Code changes to implement the date error scenarios with more specific ones

Below have been done as part this PR

- [x] add new tests and update the existing tests
- [x] relevant code changes
- [x] new message keys
- [x] refactoring in SelectLocalDateFormatter by reordering the methods and making reusable methods
- [x] other minor refactoring
- [x] fix test in ConfirmationPageSpec