### PR TITLE
[MMCA-5032]  - Display selected dates page on cash account statement request journey

### DIFF
--- a/app/controllers/SelectedTransactionsController.scala
+++ b/app/controllers/SelectedTransactionsController.scala
@@ -104,6 +104,21 @@ class SelectedTransactionsController @Inject()(selectedTransactionsView: selecte
     }
   }
 
+  def duplicateDates(displayMsg: String, startDate: String, endDate: String): Action[AnyContent] =
+    identify.async {
+      implicit req =>
+        Future.successful(Ok(duplicateDatesView(displayMsg, startDate, endDate)))
+    }
+
+  def tooManyTransactionsSelected(dateRange: RequestedDateRange): Action[AnyContent] =
+    identify {
+      implicit req =>
+        Ok(tooManyResults(
+          new ResultsPageSummary(dateRange.from, dateRange.to),
+          controllers.routes.SelectTransactionsController.onPageLoad().url)
+        )
+    }
+
   private def checkAccountAndDatesThenRedirect(optionalAccount: Option[CashAccount],
                                                optionalDates: Option[CashTransactionDates])
                                               (implicit request: IdentifierRequest[AnyContent]) = {
@@ -143,19 +158,4 @@ class SelectedTransactionsController @Inject()(selectedTransactionsView: selecte
       )
     )
   }
-
-  def duplicateDates(displayMsg: String, startDate: String, endDate: String): Action[AnyContent] =
-    identify.async {
-      implicit req =>
-        Future.successful(Ok(duplicateDatesView(displayMsg, startDate, endDate)))
-    }
-
-  def tooManyTransactionsSelected(dateRange: RequestedDateRange): Action[AnyContent] =
-    identify {
-      implicit req =>
-        Ok(tooManyResults(
-          new ResultsPageSummary(dateRange.from, dateRange.to),
-          controllers.routes.SelectTransactionsController.onPageLoad().url)
-        )
-    }
 }

--- a/app/controllers/SelectedTransactionsController.scala
+++ b/app/controllers/SelectedTransactionsController.scala
@@ -20,7 +20,9 @@ import cats.data.EitherT
 import cats.data.EitherT.fromOptionF
 import cats.implicits.*
 import config.{AppConfig, ErrorHandler}
-import connectors.{CustomsFinancialsApiConnector, EntryAlreadyExists, ErrorResponse, ExceededMaximum, TooManyTransactionsRequested}
+import connectors.{
+  CustomsFinancialsApiConnector, EntryAlreadyExists, ErrorResponse, ExceededMaximum, TooManyTransactionsRequested
+}
 import controllers.actions.IdentifierAction
 import helpers.Formatters.dateAsMonthAndYear
 import models.*
@@ -35,8 +37,7 @@ import views.html.*
 
 import java.time.LocalDate
 import javax.inject.Inject
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 
 class SelectedTransactionsController @Inject()(selectedTransactionsView: selected_transactions,
                                                apiConnector: CustomsFinancialsApiConnector,

--- a/app/views/selected_transactions.scala.html
+++ b/app/views/selected_transactions.scala.html
@@ -28,7 +28,6 @@
 
 @(
         summary: ResultsPageSummary,
-        returnLink: String,
         accountNumber: String
 )(
         implicit request: Request[_],

--- a/test/controllers/SelectedTransactionsControllerSpec.scala
+++ b/test/controllers/SelectedTransactionsControllerSpec.scala
@@ -61,121 +61,12 @@ class SelectedTransactionsControllerSpec extends SpecBase {
       when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
         .thenReturn(Future.successful(Some(cashAccount)))
 
-      when(mockCustomsFinancialsApiConnector.retrieveHistoricCashTransactions(eqTo(cashAccountNumber), any, any)(any))
-        .thenReturn(Future.successful(Right(cashTransactionResponse)))
-
       val request: FakeRequest[AnyContentAsEmpty.type] =
         fakeRequest(GET, routes.SelectedTransactionsController.onPageLoad().url)
 
       running(app) {
         val result = route(app, request).value
         status(result) mustBe OK
-      }
-    }
-
-    "return No Transactions view when no data is returned for the search" in new Setup {
-
-      when(mockRequestedTransactionsCache.get(any))
-        .thenReturn(Future.successful(Some(CashTransactionDates(LocalDate.now(), LocalDate.now()))))
-
-      when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
-        .thenReturn(Future.successful(Some(cashAccount)))
-
-      when(mockCustomsFinancialsApiConnector.retrieveHistoricCashTransactions(eqTo(cashAccountNumber), any, any)(any))
-        .thenReturn(Future.successful(Left(NoTransactionsAvailable)))
-
-      val request: FakeRequest[AnyContentAsEmpty.type] =
-        fakeRequest(GET, routes.SelectedTransactionsController.onPageLoad().url)
-
-      running(app) {
-        val result = route(app, request).value
-        status(result) mustBe OK
-        contentAsString(result) must include regex "No cash account transactions"
-      }
-    }
-
-    "return Exceeded Threshold view when too many results returned for the search" in new Setup {
-
-      when(mockRequestedTransactionsCache.get(any))
-        .thenReturn(Future.successful(Some(CashTransactionDates(LocalDate.now(), LocalDate.now()))))
-
-      when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
-        .thenReturn(Future.successful(Some(cashAccount)))
-
-      when(mockCustomsFinancialsApiConnector.retrieveHistoricCashTransactions(eqTo(cashAccountNumber), any, any)(any))
-        .thenReturn(Future.successful(Left(TooManyTransactionsRequested)))
-
-      val request: FakeRequest[AnyContentAsEmpty.type] =
-        fakeRequest(GET, routes.SelectedTransactionsController.onPageLoad().url)
-
-      running(app) {
-        val result = route(app, request).value
-        status(result) mustBe SEE_OTHER
-      }
-    }
-
-    "return transaction unavailable for internal server error during search" in new Setup {
-
-      when(mockRequestedTransactionsCache.get(any))
-        .thenReturn(Future.successful(Some(CashTransactionDates(LocalDate.now(), LocalDate.now()))))
-
-      when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
-        .thenReturn(Future.successful(Some(cashAccount)))
-
-      when(mockCustomsFinancialsApiConnector.retrieveHistoricCashTransactions(eqTo(cashAccountNumber), any, any)(any))
-        .thenReturn(Future.successful(Left(UnknownException)))
-
-      val request: FakeRequest[AnyContentAsEmpty.type] =
-        fakeRequest(GET, routes.SelectedTransactionsController.onPageLoad().url)
-
-      running(app) {
-        val result = route(app, request).value
-        status(result) mustBe OK
-      }
-    }
-
-    "when too many results returned for the search" in new Setup {
-
-      val day = 30
-      val month = 3
-      val year = 2023
-
-      when(mockRequestedTransactionsCache.get(any))
-        .thenReturn(Future.successful(Some(CashTransactionDates(
-          LocalDate.of(year, month, day), LocalDate.of(year, month, day)))))
-
-      when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
-        .thenReturn(Future.successful(Some(cashAccount)))
-
-      when(mockCustomsFinancialsApiConnector.retrieveHistoricCashTransactions(eqTo(cashAccountNumber), any, any)(any))
-        .thenReturn(Future.successful(Left(TooManyTransactionsRequested)))
-
-      val request: FakeRequest[AnyContentAsEmpty.type] =
-        fakeRequest(GET, routes.SelectedTransactionsController.onPageLoad().url)
-
-      running(app) {
-        val result = route(app, request).value
-        status(result) mustBe SEE_OTHER
-      }
-    }
-
-    "redirect to account unavailable page when exception is thrown" in new Setup {
-
-      when(mockRequestedTransactionsCache.get(any))
-        .thenReturn(Future.successful(Some(CashTransactionDates(LocalDate.now(), LocalDate.now()))))
-
-      when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
-        .thenReturn(Future.successful(Some(cashAccount)))
-
-      when(mockCustomsFinancialsApiConnector.retrieveHistoricCashTransactions(eqTo(cashAccountNumber), any, any)(any))
-        .thenThrow(new RuntimeException())
-
-      val request: FakeRequest[AnyContentAsEmpty.type] =
-        fakeRequest(GET, routes.SelectedTransactionsController.onPageLoad().url)
-
-      running(app) {
-        val result = route(app, request).value
-        status(result) mustBe SEE_OTHER
       }
     }
   }

--- a/test/views/SelectedTransactionsSpec.scala
+++ b/test/views/SelectedTransactionsSpec.scala
@@ -58,12 +58,9 @@ class SelectedTransactionsSpec extends ViewTestHelper {
     val toDate: LocalDate = LocalDate.of(year, month, day11th)
 
     val summary: ResultsPageSummary = new ResultsPageSummary(fromDate, toDate)
-    val returnLink: String = "some return link"
     val accountNumber: String = "some account number"
     val displayAccountNumberFormat: String = s"Account: $accountNumber"
 
-    val view: Document =
-      Jsoup.parse(app.injector.instanceOf[selected_transactions].apply(
-        summary, returnLink, accountNumber).body)
+    val view: Document = Jsoup.parse(app.injector.instanceOf[selected_transactions].apply(summary, accountNumber).body)
   }
 }


### PR DESCRIPTION
Description - Code changes for the bug that resulted to incorrect page after providing the requested dates on Select Transactions page

Below have been done as part of this PR

- [x] remove the incorrect and unnecessary ACC31 api call as part of SelectedTransactionsController.onPageLoad
- [x] remove related tests
- [x] remove redundant code from the controller
- [x] remove incorrect and redundant parameter from selected_transactions.scala.html
- [x] reordering of the public methods in SelectedTransactionsController
- [x] minor refactoring

https://jira.tools.tax.service.gov.uk/browse/MMCA-5032