### PR TITLE
MMCA-5053 Enable compatibility with Java 21

### DIFF
--- a/app/crypto/EncryptedValue.scala
+++ b/app/crypto/EncryptedValue.scala
@@ -39,7 +39,7 @@ class AesGCMCrypto @Inject()() {
 
   private val IV_SIZE = 96
   private val TAG_BIT_LENGTH = 128
-  val ALGORITHM_TO_TRANSFORM_STRING = "AES/GCM/PKCS5Padding"
+  val ALGORITHM_TO_TRANSFORM_STRING = "AES/GCM/NoPadding"
   private lazy val secureRandom = new SecureRandom()
   val ALGORITHM_KEY = "AES"
   private val METHOD_ENCRYPT = "encrypt"

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import scoverage.ScoverageKeys
-import uk.gov.hmrc.DefaultBuildSettings.{targetJvm, itSettings}
+import uk.gov.hmrc.DefaultBuildSettings.itSettings
 
 val appName = "customs-cash-account-frontend"
 
@@ -30,7 +30,6 @@ lazy val microservice = Project(appName, file("."))
   .disablePlugins(JUnitXmlReportPlugin)
   .settings(scalastyleSettings)
   .settings(
-    targetJvm := "jvm-11",
     update / evictionWarningOptions :=
       EvictionWarningOptions.default.withWarnScalaVersionEviction(true),
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,


### PR DESCRIPTION
Remove targetJvm setting in sbt as per platform guidance

Remove padding scheme as this throws exceptions in Java 21 and is not required for GCM anyhow