### PR TITLE
[MMCA-5238] Updated link to return link to financialsHomepage

### DIFF
--- a/app/views/confirmation_page.scala.html
+++ b/app/views/confirmation_page.scala.html
@@ -67,7 +67,7 @@
 
   @link(
     linkMessage = Some(messages(s"cf.cash-account.transactions.confirmation.back")),
-    location = controllers.routes.CashAccountController.showAccountDetails(None).url,
+    location = appConfig.customsFinancialsFrontendHomepage,
     pId = Some("link-text"),
     pClass = "govuk-body govuk-!-margin-bottom-9")
 }

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -320,7 +320,7 @@ cf.cash-account.transactions.confirmation.statements=Mae’ch cais am drafodion 
 cf.cash-account.transactions.confirmation.next=Yr hyn sy’n digwydd nesaf
 cf.cash-account.transactions.confirmation.email=Byddwn yn anfon e-bost at <strong>{0}</strong> cyn pen 48 awr pan fydd eich cais wedi’i brosesu.
 cf.cash-account.transactions.confirmation.download=Byddwch yn gallu lawrlwytho’ch trafodion o’r dudalen trafodion cyfrifon arian parod.
-cf.cash-account.transactions.confirmation.back=Yn ôl i ‘cyfrif arian parod’
+cf.cash-account.transactions.confirmation.back=Yn ôl i hafan ‘Rheoli tollau mewnforio a chyfrifon TAW’
 
 cf.cash-account.detail.transactions= Trafodion
 cf.cash-account.detail.payments-caption=Eich taliadau ar gyfer {0}

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -318,7 +318,7 @@ cf.cash-account.transactions.confirmation.statements=We received your request fo
 cf.cash-account.transactions.confirmation.next=What happens next
 cf.cash-account.transactions.confirmation.email=We’ll send an email within 48 hours to <strong>{0}</strong> when your request is processed.
 cf.cash-account.transactions.confirmation.download=You’ll be able to download your transactions from the cash account transactions page.
-cf.cash-account.transactions.confirmation.back=Back to cash account
+cf.cash-account.transactions.confirmation.back=Back to Manage import duties and VAT accounts homepage
 
 site.continue=Confirm and send
 

--- a/test/views/ConfirmationPageSpec.scala
+++ b/test/views/ConfirmationPageSpec.scala
@@ -63,8 +63,10 @@ class ConfirmationPageSpec extends SpecBase with ViewTestHelper {
         )
       }
 
-      "link text is correct" in new Setup {
-        view.getElementById("link-text").text() mustBe messages("cf.cash-account.transactions.confirmation.back")
+      "link text is correct and points to the right URL" in new Setup {
+        val linkElement = view.getElementById("link-text").selectFirst("a")
+        linkElement.text() mustBe messages("cf.cash-account.transactions.confirmation.back")
+        linkElement.attr("href") mustBe appConfig.customsFinancialsFrontendHomepage
       }
     }
   }


### PR DESCRIPTION
[Tasks]
- Replaced `controllers.routes.CashAccountController.showAccountDetails(None).url` with `appConfig.customsFinancialsFrontendHomepage` in `confirmation_page`.
- Updated translation files
- Unit tests updated