### PR TITLE
MMCA-5338: updating confirmation page with research links

### DIFF
--- a/app/views/confirmation_page.scala.html
+++ b/app/views/confirmation_page.scala.html
@@ -21,6 +21,7 @@
 @this(
   layout: Layout,
   link: components.link,
+  newTabLink: components.newTabLink,
   p: components.p,
   h2: components.h2,
   govukPanel: GovukPanel
@@ -70,4 +71,21 @@
     location = appConfig.customsFinancialsFrontendHomepage,
     pId = Some("link-text"),
     pClass = "govuk-body govuk-!-margin-bottom-9")
+
+  @h2(
+    msg = messages("cf.cash-account.transactions.confirmation.help.subheader-text"),
+    classes = "govuk-heading-s",
+    id=Some("improve-the-service-subheader-text")
+  )
+
+  @p(
+    message = s"${messages("cf.cash-account.transactions.confirmation.help.body-text")}",
+    id=Some("improve-the-service-body")
+  )
+
+  @newTabLink(
+    linkMessage = messages("cf.cash-account.transactions.confirmation.help.link"),
+    href = appConfig.helpMakeGovUkBetterUrl,
+    classes = "govuk-body improve-the-service-link"
+  )
 }

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -322,9 +322,9 @@ cf.cash-account.transactions.confirmation.email=Byddwn yn anfon e-bost at <stron
 cf.cash-account.transactions.confirmation.download=Byddwch yn gallu lawrlwytho’ch trafodion o’r dudalen trafodion cyfrifon arian parod.
 cf.cash-account.transactions.confirmation.back=Yn ôl i hafan ‘Rheoli tollau mewnforio a chyfrifon TAW’
 
-cf.cash-account.transactions.confirmation.help.subheader-text=Help us improve the service
-cf.cash-account.transactions.confirmation.help.body-text=Do you have an EU EORI number? We''re carrying out user research to help improve our services.
-cf.cash-account.transactions.confirmation.help.link=Sign up to take part in user research (opens in new tab)
+cf.cash-account.transactions.confirmation.help.subheader-text=Helpu ni i wella’r gwasanaeth hwn
+cf.cash-account.transactions.confirmation.help.body-text=A oes gennych rif EORI yn yr UE? Rydym yn cynnal ymchwil defnyddwyr i helpu i wella ein gwasanaethau.
+cf.cash-account.transactions.confirmation.help.link=Cofrestrwch i gymryd rhan mewn ymchwil defnyddwyr (yn agor tab newydd)
 
 cf.cash-account.detail.transactions= Trafodion
 cf.cash-account.detail.payments-caption=Eich taliadau ar gyfer {0}

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -322,6 +322,10 @@ cf.cash-account.transactions.confirmation.email=Byddwn yn anfon e-bost at <stron
 cf.cash-account.transactions.confirmation.download=Byddwch yn gallu lawrlwytho’ch trafodion o’r dudalen trafodion cyfrifon arian parod.
 cf.cash-account.transactions.confirmation.back=Yn ôl i hafan ‘Rheoli tollau mewnforio a chyfrifon TAW’
 
+cf.cash-account.transactions.confirmation.help.subheader-text=Help us improve the service
+cf.cash-account.transactions.confirmation.help.body-text=Do you have an EU EORI number? We''re carrying out user research to help improve our services.
+cf.cash-account.transactions.confirmation.help.link=Sign up to take part in user research (opens in new tab)
+
 cf.cash-account.detail.transactions= Trafodion
 cf.cash-account.detail.payments-caption=Eich taliadau ar gyfer {0}
 cf.cash-account.detail.transactions-caption=Eich trafodion ar gyfer {0}

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -320,6 +320,10 @@ cf.cash-account.transactions.confirmation.email=We’ll send an email within 48 
 cf.cash-account.transactions.confirmation.download=You’ll be able to download your transactions from the cash account transactions page.
 cf.cash-account.transactions.confirmation.back=Back to Manage import duties and VAT accounts homepage
 
+cf.cash-account.transactions.confirmation.help.subheader-text=Help us improve the service
+cf.cash-account.transactions.confirmation.help.body-text=Do you have an EU EORI number? We''re carrying out user research to help improve our services.
+cf.cash-account.transactions.confirmation.help.link=Sign up to take part in user research (opens in new tab)
+
 site.continue=Confirm and send
 
 cf.cash-account.detail.transactions= Transactions

--- a/test/views/ConfirmationPageSpec.scala
+++ b/test/views/ConfirmationPageSpec.scala
@@ -68,6 +68,24 @@ class ConfirmationPageSpec extends SpecBase with ViewTestHelper {
         linkElement.text() mustBe messages("cf.cash-account.transactions.confirmation.back")
         linkElement.attr("href") mustBe appConfig.customsFinancialsFrontendHomepage
       }
+
+      "Page must contain correct research header text" in new Setup {
+        view.getElementById("improve-the-service-subheader-text").text() mustBe messages(
+          "cf.cash-account.transactions.confirmation.help.subheader-text"
+        )
+      }
+
+      "Page must contain correct research description text" in new Setup {
+        view.getElementById("improve-the-service-body").text() mustBe messages(
+          "cf.cash-account.transactions.confirmation.help.body-text"
+        )
+      }
+
+      "Page must contain correct research header link" in new Setup {
+        view.getElementsByClass("improve-the-service-link").text() mustBe messages(
+          "cf.cash-account.transactions.confirmation.help.link"
+        )
+      }
     }
   }
 

--- a/test/views/ConfirmationPageSpec.scala
+++ b/test/views/ConfirmationPageSpec.scala
@@ -20,6 +20,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import utils.SpecBase
 import views.html.confirmation_page
+import utils.Utils.{period, singleSpace}
 
 class ConfirmationPageSpec extends SpecBase with ViewTestHelper {
 
@@ -36,11 +37,6 @@ class ConfirmationPageSpec extends SpecBase with ViewTestHelper {
 
       "header 1 is correct" in new Setup {
         view.getElementsByTag("h1").text() mustBe messages("cf.cash-account.transactions.confirmation.statements")
-      }
-
-      "header 2 is correct" in new Setup {
-        view.getElementsByTag("h2").text() mustBe
-          "Help make GOV.UK better What happens next Support links"
       }
 
       "email confirmation is correct" in new Setup {
@@ -82,8 +78,10 @@ class ConfirmationPageSpec extends SpecBase with ViewTestHelper {
       }
 
       "Page must contain correct research header link" in new Setup {
+        val pre = messages("cf.cash-account.transactions.confirmation.help.link")
+
         view.getElementsByClass("improve-the-service-link").text() mustBe messages(
-          "cf.cash-account.transactions.confirmation.help.link"
+          s"$pre$singleSpace$period"
         )
       }
     }


### PR DESCRIPTION
This PR adds help request links to the confirmation page

https://jira.tools.tax.service.gov.uk/browse/MMCA-5338

This alligns /customs/cash-account/selected-confirmation with https://customs-financials-prototype.herokuapp.com/version33/CashAccount/request-older-cash-account_confirmation

Note - A couple issues with this one, worth checking out 

1 - i can see the confirmation page I was expecting at customs/cash-account/selected-confirmation but I see a different page at /customs/cash-account/requested-cash-transactions when following the user journey. Ive updated a confirmation page but not sure if its the right one.

2 - thought the repo all the external links seem to have trailing spaces followed by periods. For consistency sake I continued to use the same pattern however the designs have it correct (I will check on this tomorrow). I recommend as a follow up to create a new ticket if it doesn't exist already to fix this as it most certainly will be a WCAG fail

3 - there seemed to be an unfortunate test in this page checking for a h2 that was breaking this file (as i have added a second h2). i have attempted to find it in this page, project, and across the repos i have installed but dont know where it is coming from. I have removed the test for now but it may need to be added back and amended later.

feedback kindly requested on the above points 