### PR TITLE
[MMCA-5411] - Map 404 status code correctly for ACC44 and ACC45 calls

### DIFF
--- a/app/connectors/CustomsFinancialsApiConnector.scala
+++ b/app/connectors/CustomsFinancialsApiConnector.scala
@@ -193,6 +193,10 @@ class CustomsFinancialsApiConnector @Inject() (
       logger.error("SERVICE_UNAVAILABLE for retrieveCashTransactionsBySearch")
       Left(ServiceUnavailableErrorResponse)
 
+    case UpstreamErrorResponse(_, NOT_FOUND, _, _) =>
+      logger.warn("Data not found for retrieveCashTransactionsBySearch")
+      Left(NoAssociatedDataFound)
+
     case e =>
       logger.error(s"Unknown error for retrieveCashTransactionsBySearch :${e.getMessage}")
       Left(UnknownException)

--- a/app/connectors/CustomsFinancialsApiConnector.scala
+++ b/app/connectors/CustomsFinancialsApiConnector.scala
@@ -308,6 +308,10 @@ class CustomsFinancialsApiConnector @Inject() (
         logger.error("Internal Server error while calling ETMP")
         Left(InternalServerErrorErrorResponse)
 
+      case NOT_FOUND =>
+        logger.warn("Data not found for the search")
+        Left(NoAssociatedDataFound)
+
       case _ =>
         logger.error("Service Unavailable error while calling ETMP")
         Left(ServiceUnavailableErrorResponse)

--- a/app/connectors/CustomsFinancialsApiConnector.scala
+++ b/app/connectors/CustomsFinancialsApiConnector.scala
@@ -252,6 +252,10 @@ class CustomsFinancialsApiConnector @Inject() (
       logger.error("SERVICE_UNAVAILABLE for postCashAccountStatements")
       Left(ServiceUnavailableErrorResponse)
 
+    case UpstreamErrorResponse(_, NOT_FOUND, _, _) =>
+      logger.warn("Data not found for postCashAccountStatements")
+      Left(NoAssociatedDataFound)
+
     case e =>
       logger.error(s"Unknown error for postCashAccountStatements :${e.getMessage}")
       Left(UnknownException)

--- a/app/controllers/SelectedTransactionsController.scala
+++ b/app/controllers/SelectedTransactionsController.scala
@@ -18,7 +18,8 @@ package controllers
 
 import config.{AppConfig, ErrorHandler}
 import connectors.{
-  CustomsFinancialsApiConnector, EntryAlreadyExists, ErrorResponse, ExceededMaximum, TooManyTransactionsRequested
+  CustomsFinancialsApiConnector, EntryAlreadyExists, ErrorResponse, ExceededMaximum, NoAssociatedDataFound,
+  TooManyTransactionsRequested
 }
 import controllers.actions.IdentifierAction
 import helpers.Formatters.dateAsMonthAndYear
@@ -147,12 +148,19 @@ class SelectedTransactionsController @Inject() (
 
           case Left(ExceededMaximum) => Redirect(routes.SelectedTransactionsController.requestedTooManyTransactions())
 
-          case _ =>
-            logger.error(s"Error posting cash account statements")
+          case Left(errorResponse: ErrorResponse) =>
+            logErrorMessage(errorResponse)
             Redirect(routes.CashAccountController.showAccountDetails(None))
         }
 
       case _ => Future.successful(Redirect(routes.CashAccountController.showAccountDetails(None)))
+    }
+
+  private def logErrorMessage(errorResponse: ErrorResponse): Unit =
+    if (errorResponse == NoAssociatedDataFound) {
+      logger.warn("Data not found for the request")
+    } else {
+      logger.error("Error posting cash account statements")
     }
 
   private def displayResultView(account: CashAccount, from: LocalDate, to: LocalDate)(implicit

--- a/test/connectors/CustomsFinancialsApiConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsApiConnectorSpec.scala
@@ -398,9 +398,12 @@ class CustomsFinancialsApiConnectorSpec extends SpecBase {
 
       when(mockHttpClient.post(any[URL]())(any())).thenReturn(requestBuilder)
 
+      when(mockCashAccountSearchRepository.get(any[String])).thenReturn(Future.successful(None))
+
       val appWithMocks: Application = applicationBuilder
         .overrides(
-          bind[HttpClientV2].toInstance(mockHttpClient)
+          bind[HttpClientV2].toInstance(mockHttpClient),
+          bind[CashAccountSearchRepository].toInstance(mockCashAccountSearchRepository)
         )
         .build()
 

--- a/test/test-scalastyle-config.xml
+++ b/test/test-scalastyle-config.xml
@@ -3,7 +3,7 @@
     <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
     <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
         <parameters>
-            <parameter name="maxFileLength"><![CDATA[1100]]></parameter>
+            <parameter name="maxFileLength"><![CDATA[1200]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false">


### PR DESCRIPTION
Description - Handle 404 response for ACC44 and ACC45 calls

Below has been done as part of this PR

- [ ] add case statements to handle 404
- [ ] add tests
- [ ] minor refactoring