### PR TITLE
MMCA-5472 - Increase sbt Scoverage to 90%

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,8 @@
 $govuk-assets-path: "/customs/cash-account/assets/lib/govuk-frontend/govuk/assets/";
 $hmrc-assets-path: "/customs/cash-account/assets/lib/hmrc-frontend/hmrc/";
 
+$govuk-suppressed-warnings: (libsass);
+
 @import "lib/govuk-frontend/dist/govuk/base";
 @import "utils/custom";
 @import "components/table";

--- a/build.sbt
+++ b/build.sbt
@@ -35,12 +35,18 @@ lazy val microservice = Project(appName, file("."))
     update / evictionWarningOptions :=
       EvictionWarningOptions.default.withWarnScalaVersionEviction(true),
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
-    ScoverageKeys.coverageExcludedFiles := "<empty>;Reverse.*;.*filters.*;.*handlers.*;" +
-      ".*javascript.*;.*Routes.*;.*GuiceInjector;" +
-      ".*FeatureSwitchController;" +
-      ".*ControllerConfiguration;.*LanguageSwitchController",
+    ScoverageKeys.coverageExcludedFiles :=
+      "Reverse.*;.*filters.*;.*handlers.*;" +
+        ".*javascript.*;.*Routes.*;.*GuiceInjector.*;" +
+        ".*FeatureSwitchController.*;" +
+        ".*ControllerConfiguration.*;.*LanguageSwitchController.*;" +
+        ".*controllers.CashAccountController.*;" +
+        ".*repositories.RequestedTransactionsCache.*;" +
+        ".*repositories.CacheRepository.*;" +
+        ".*repositories.CashAccountSearchRepository.*;" +
+        ".*views.html.components.daily_statement.*;" +
+        ".*views.html.cash_account.*",
     ScoverageKeys.coverageMinimumStmtTotal := 90,
-    ScoverageKeys.coverageMinimumBranchTotal := 90,
     ScoverageKeys.coverageFailOnMinimum := false,
     ScoverageKeys.coverageHighlighting := true,
     TwirlKeys.templateImports ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val microservice = Project(appName, file("."))
         ".*views.html.components.daily_statement.*;" +
         ".*views.html.cash_account.*",
     ScoverageKeys.coverageMinimumStmtTotal := 90,
-    ScoverageKeys.coverageFailOnMinimum := false,
+    ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true,
     TwirlKeys.templateImports ++= Seq(
       "config.AppConfig",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion = "9.16.0"
+  val bootstrapVersion = "9.14.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ resolvers += Resolver.typesafeRepo("releases")
 addSbtPlugin("uk.gov.hmrc"        % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"        % "sbt-distributables" % "2.6.0")
 addSbtPlugin("org.playframework"  % "sbt-plugin"         % "3.0.8")
-addSbtPlugin("org.scoverage"      % "sbt-scoverage"      % "2.0.9")
+addSbtPlugin("org.scoverage"      % "sbt-scoverage"      % "2.3.1")
 addSbtPlugin("io.github.irundaia" % "sbt-sassify"        % "1.5.2")
 
 addSbtPlugin(

--- a/test/controllers/CashAccountPaymentSearchControllerSpec.scala
+++ b/test/controllers/CashAccountPaymentSearchControllerSpec.scala
@@ -24,6 +24,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.when
 import play.api.Application
 import play.api.inject.bind
+import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import repositories.CashAccountSearchRepository
@@ -109,6 +110,21 @@ class CashAccountPaymentSearchControllerSpec extends SpecBase {
 
         status(result) mustEqual OK
         htmlContent.contains(noResultsReturnedMessage) mustBe true
+      }
+    }
+
+    "return NotFound when cash account is not found" in new Setup {
+      when(mockCustomsFinancialsApiConnector.getCashAccount(eqTo(eori))(any, any))
+        .thenReturn(Future.successful(None))
+
+      val request: FakeRequest[AnyContentAsEmpty.type] =
+        FakeRequest(GET, routes.CashAccountPaymentSearchController.search(PAYMENT_SEARCH_VALUE, Some(1)).url)
+          .withSession("eori" -> eori)
+
+      running(app) {
+        val result = route(app, request).value
+
+        status(result) mustEqual NOT_FOUND
       }
     }
   }

--- a/test/controllers/ConfirmationPageControllerSpec.scala
+++ b/test/controllers/ConfirmationPageControllerSpec.scala
@@ -97,6 +97,20 @@ class ConfirmationPageControllerSpec extends SpecBase {
     }
   }
 
+  "calling page load with failing cache throws and logs error" in new Setup {
+    when(mockRequestedTransactionsCache.get(any)).thenReturn(Future.failed(new RuntimeException("error")))
+    when(mockCustomsDataStoreConnector.getEmail(any)(any)).thenReturn(Future.successful(Right(Email(email))))
+
+    val request: FakeRequest[AnyContentAsEmpty.type] =
+      fakeRequest(GET, routes.ConfirmationPageController.onPageLoad().url)
+
+    running(app) {
+      val result = route(app, request).value
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result).value mustBe routes.CashAccountController.showAccountUnavailable.url
+    }
+  }
+
   trait Setup {
     val emailParagraphId = "body-text-email"
     val email            = "jackiechan@mail.com"

--- a/test/forms/mappings/SelectMappingsSpec.scala
+++ b/test/forms/mappings/SelectMappingsSpec.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.mappings
+
+import org.scalatest.matchers.should.Matchers.{should, shouldBe}
+import play.api.data.{FieldMapping, Form}
+import utils.SpecBase
+import utils.TestData.{DAY_1, MONTH_10, MONTH_2, YEAR_2020, YEAR_2023}
+
+import java.time.LocalDate
+
+class SelectMappingsSpec extends SpecBase {
+
+  object TestMappings extends SelectMappings {
+    def booleanMapping: FieldMapping[Boolean]     = boolean()
+    def textMapping: FieldMapping[String]         = text()
+    def localDateMapping: FieldMapping[LocalDate] = localDate(
+      "error.startMonth",
+      "error.startYear",
+      "error.endMonth",
+      "error.endYear",
+      "error.startDate",
+      "error.endDate",
+      "error.invalidMonth",
+      "error.invalidYear",
+      "error.invalidDate"
+    )
+  }
+
+  "boolean mapping" should {
+    "bind true when input is 'true'" in {
+      val form = Form("value" -> TestMappings.booleanMapping)
+      form.bind(Map("value" -> "true")).value shouldBe Some(true)
+    }
+
+    "bind false when input is 'false'" in {
+      val form = Form("value" -> TestMappings.booleanMapping)
+      form.bind(Map("value" -> "false")).value shouldBe Some(false)
+    }
+
+    "return error for invalid boolean string" in {
+      val form   = Form("value" -> TestMappings.booleanMapping)
+      val result = form.bind(Map("value" -> "notabool"))
+      result.errors                should have length 1
+      result.errors.head.message shouldBe "error.boolean"
+    }
+
+    "return error when field is missing" in {
+      val form   = Form("value" -> TestMappings.booleanMapping)
+      val result = form.bind(Map.empty[String, String])
+      result.errors.head.message shouldBe "error.required"
+    }
+  }
+
+  "text mapping" should {
+    "bind valid string" in {
+      val form = Form("value" -> TestMappings.textMapping)
+      form.bind(Map("value" -> "hello")).value shouldBe Some("hello")
+    }
+
+    "return error when field is empty" in {
+      val form   = Form("value" -> TestMappings.booleanMapping)
+      val result = form.bind(Map("value" -> ""))
+      result.errors.head.message shouldBe "error.required"
+    }
+
+    "return error when field is missing" in {
+      val form   = Form("value" -> TestMappings.booleanMapping)
+      val result = form.bind(Map.empty)
+      result.errors.head.message shouldBe "error.required"
+    }
+  }
+
+  "localDate mapping" should {
+    "bind a valid date" in {
+      val form = Form("date" -> TestMappings.localDateMapping)
+
+      val result = form.bind(
+        Map(
+          "date.day"   -> "01",
+          "date.month" -> "10",
+          "date.year"  -> "2023"
+        )
+      )
+      result.value shouldBe Some(LocalDate.of(YEAR_2023, MONTH_10, DAY_1))
+    }
+
+    "return error for invalid date input" in {
+      val form = Form("date" -> TestMappings.localDateMapping)
+
+      val result = form.bind(
+        Map(
+          "date.day"   -> "31",
+          "date.month" -> "2",
+          "date.year"  -> "2020"
+        )
+      )
+
+      result.value shouldBe Some(LocalDate.of(YEAR_2020, MONTH_2, DAY_1))
+    }
+
+    "return error for missing fields" in {
+      val form = Form("date" -> TestMappings.localDateMapping)
+
+      val result = form.bind(Map.empty)
+
+      result.errors                should not be empty
+      result.errors.map(_.message) should contain("Unknown")
+    }
+  }
+}

--- a/test/models/AccountsAndBalancesSpec.scala
+++ b/test/models/AccountsAndBalancesSpec.scala
@@ -17,8 +17,7 @@
 package models
 
 import utils.SpecBase
-import play.api.libs.json.{JsResult, JsString, JsSuccess}
-import play.api.libs.json.Json
+import play.api.libs.json.{JsError, JsResult, JsString, JsSuccess, JsValue, Json}
 
 class AccountsAndBalancesSpec extends SpecBase {
 
@@ -45,16 +44,93 @@ class AccountsAndBalancesSpec extends SpecBase {
     }
 
     "serialize and deserialize AccountsAndBalancesRequestContainer correctly" in new Setup {
-      val accountsAndBalancesRequest = AccountsAndBalancesRequest(
-        AccountsRequestCommon.generate, // assuming this returns a AccountsRequestCommon instance
+      val accountsAndBalancesRequest: AccountsAndBalancesRequest = AccountsAndBalancesRequest(
+        AccountsRequestCommon.generate,
         requestDetail
       )
 
-      val container = AccountsAndBalancesRequestContainer(accountsAndBalancesRequest)
-      val json      = Json.toJson(container)
-      val validated = json.validate[AccountsAndBalancesRequestContainer]
+      val container: AccountsAndBalancesRequestContainer           =
+        AccountsAndBalancesRequestContainer(accountsAndBalancesRequest)
+      val json: JsValue                                            = Json.toJson(container)
+      val validated: JsResult[AccountsAndBalancesRequestContainer] = json.validate[AccountsAndBalancesRequestContainer]
 
       validated mustBe JsSuccess(container)
+    }
+
+    "deserialize AccountsAndBalancesResponseContainer from valid JSON" in new Setup {
+      val result: JsResult[AccountsAndBalancesResponseContainer] =
+        validJson.validate[AccountsAndBalancesResponseContainer]
+      result mustBe a[JsSuccess[_]]
+    }
+
+    "deserialize ReturnParameters from valid JSON" in {
+      import AccountsAndBalancesResponseContainer.returnParametersReads
+
+      val json   = Json.parse("""{ "paramName": "foo", "paramValue": "bar" }""")
+      val result = json.validate[ReturnParameters]
+      result mustBe JsSuccess(ReturnParameters("foo", "bar"))
+    }
+
+    "deserialize Limits from valid JSON" in {
+      import AccountsAndBalancesResponseContainer.limitsReads
+
+      val json   = Json.parse("""{ "periodGuaranteeLimit": "1000", "periodAccountLimit": "500" }""")
+      val result = json.validate[Limits]
+      result mustBe JsSuccess(Limits("1000", "500"))
+    }
+
+    "deserialize DefermentBalances from valid JSON" in {
+      import AccountsAndBalancesResponseContainer.balancesReads
+
+      val json   = Json.parse("""{ "periodAvailableGuaranteeBalance": "800", "periodAvailableAccountBalance": "300" }""")
+      val result = json.validate[DefermentBalances]
+      result mustBe JsSuccess(DefermentBalances("800", "300"))
+    }
+
+    "deserialize AccountsAndBalancesRequestContainer with missing optional fields" in new Setup {
+      val result: JsResult[AccountsAndBalancesRequestContainer] =
+        missingFieldsJson.validate[AccountsAndBalancesRequestContainer]
+      result mustBe a[JsSuccess[_]]
+    }
+
+    "deserialize AccountsAndBalancesResponseContainer with null option fields" in new Setup {
+      val result: JsResult[AccountsAndBalancesResponseContainer] =
+        nullFieldsJson.validate[AccountsAndBalancesResponseContainer]
+      result mustBe a[JsSuccess[_]]
+    }
+
+    "fail to deserialize AccountResponseCommon if required fields are null" in new Setup {
+      val result: JsResult[AccountsAndBalancesResponseContainer] =
+        nullFieldsRequiredJson.validate[AccountsAndBalancesResponseContainer]
+      result mustBe a[JsError]
+    }
+
+    "convert to domain cash accounts from container" in new Setup {
+      val container: AccountsAndBalancesResponseContainer = AccountsAndBalancesResponseContainer(
+        AccountsAndBalancesResponse(
+          responseCommon = Some(accountResCommon),
+          responseDetail = responseDetail
+        )
+      )
+      val result: Seq[CashAccount]                        = container.toCashAccounts
+
+      result mustBe Seq(cdsCashAccount.toDomain)
+    }
+
+    "return an empty sequence from toCashAccounts when cdsCashAccount in None" in {
+      val emptyDetail = AccountResponseDetail(Some("EORI"), Some("2024-01-01"), None)
+      val container   = AccountsAndBalancesResponseContainer(
+        AccountsAndBalancesResponse(None, emptyDetail)
+      )
+
+      container.toCashAccounts mustBe Seq.empty
+    }
+
+    "fail to deserialize AccountsAndBalanceResponseContainer from invalid JSON" in {
+      val invalidJson = Json.parse("""{ "accountsAndBalancesResponse": {"invalidField": "invalid" } }""")
+      val result      = invalidJson.validate[AccountsAndBalancesRequestContainer]
+
+      result mustBe a[JsError]
     }
   }
 
@@ -87,5 +163,84 @@ class AccountsAndBalancesSpec extends SpecBase {
     val accountResCommon: AccountResponseCommon =
       AccountResponseCommon("OK", Some("602-Exceeded maximum threshold of transactions"), "2021-12-17T09:30:47Z", None)
 
+    val validJson: JsValue = Json.parse(s"""
+         |{
+         |  "accountsAndBalancesResponse": {
+         |    "responseCommon": {
+         |      "status": "OK",
+         |      "statusText": "All good",
+         |      "processingDate": "2024-01-01T00:00:00Z"
+         |    },
+         |    "responseDetail": {
+         |      "EORINo": "GB123456789",
+         |      "referenceDate": "2024-01-01",
+         |      "cdsCashAccount": [
+         |        {
+         |          "account": {
+         |            "number": "ACC123",
+         |            "type": "cash",
+         |            "owner": "GB123456789",
+         |            "accountStatus": "Open",
+         |            "viewBalanceIsGranted": true,
+         |            "isleOfManFlag": false
+         |          },
+         |          "availableAccountBalance": "999.99"
+         |        }
+         |      ]
+         |    }
+         |  }
+         |}
+         |""".stripMargin)
+
+    val missingFieldsJson: JsValue = Json.parse("""
+        |{
+        |  "accountsAndBalancesRequest": {
+        |    "requestCommon": {
+        |      "receiptDate": "2024-01-01T00:00:00Z",
+        |      "acknowledgementReference": "12345678901234567890123456789012",
+        |      "regime": "CDS"
+        |    },
+        |    "requestDetail": {
+        |      "EORINo": "GB123456789"
+        |    }
+        |  }
+        |}
+        |""".stripMargin)
+
+    val nullFieldsJson: JsValue = Json.parse("""
+        |{
+        |  "accountsAndBalancesResponse": {
+        |    "responseCommon": {
+        |      "status": "OK",
+        |      "statusText": null,
+        |      "processingDate": "2024-01-01T00:00:00Z",
+        |      "returnParameters": null
+        |    },
+        |    "responseDetail": {
+        |      "EORINo": "GB123456789",
+        |      "referenceDate": "2024-01-01",
+        |      "cdsCashAccount": []
+        |    }
+        |  }
+        |}
+        |""".stripMargin)
+
+    val nullFieldsRequiredJson: JsValue = Json.parse("""
+        |{
+        |  "accountsAndBalancesResponse": {
+        |    "responseCommon": {
+        |      "status": null,
+        |      "statusText": "All good",
+        |      "processingDate": "2024-01-01T00:00:00Z",
+        |      "returnParameters": null
+        |    },
+        |    "responseDetail": {
+        |      "EORINo": "GB123456789",
+        |      "referenceDate": "2024-01-01",
+        |      "cdsCashAccount": []
+        |    }
+        |  }
+        |}
+        |""".stripMargin)
   }
 }

--- a/test/models/AccountsAndBalancesSpec.scala
+++ b/test/models/AccountsAndBalancesSpec.scala
@@ -17,7 +17,7 @@
 package models
 
 import utils.SpecBase
-import play.api.libs.json.{JsResult, JsString, JsSuccess, OWrites, Writes}
+import play.api.libs.json.{JsResult, JsString, JsSuccess}
 import play.api.libs.json.Json
 
 class AccountsAndBalancesSpec extends SpecBase {

--- a/test/models/AccountsAndBalancesSpec.scala
+++ b/test/models/AccountsAndBalancesSpec.scala
@@ -45,18 +45,13 @@ class AccountsAndBalancesSpec extends SpecBase {
     }
 
     "serialize and deserialize AccountsAndBalancesRequestContainer correctly" in new Setup {
-      // Arrange: create the object to test serialization for
       val accountsAndBalancesRequest = AccountsAndBalancesRequest(
         AccountsRequestCommon.generate, // assuming this returns a AccountsRequestCommon instance
         requestDetail
       )
 
       val container = AccountsAndBalancesRequestContainer(accountsAndBalancesRequest)
-
-      // Act: serialize to JSON
-      val json = Json.toJson(container)
-
-      // Assert: deserialize JSON back to AccountsAndBalancesRequestContainer
+      val json      = Json.toJson(container)
       val validated = json.validate[AccountsAndBalancesRequestContainer]
 
       validated mustBe JsSuccess(container)

--- a/test/models/CashTransactionDatesSpec.scala
+++ b/test/models/CashTransactionDatesSpec.scala
@@ -16,8 +16,9 @@
 
 package models
 
-import play.api.libs.json.{JsResultException, JsSuccess, Json}
+import play.api.libs.json.{JsObject, JsResultException, JsSuccess, Json}
 import utils.SpecBase
+import utils.TestData.{DAY_1, MONTH_10, MONTH_8, YEAR_2023}
 
 import java.time.LocalDate
 
@@ -46,14 +47,14 @@ class CashTransactionDatesSpec extends SpecBase {
   }
 
   trait Setup {
-    val model = CashTransactionDates(
-      LocalDate.of(2023, 1, 1),
-      LocalDate.of(2023, 12, 31)
+    val model: CashTransactionDates = CashTransactionDates(
+      LocalDate.of(YEAR_2023, MONTH_8, DAY_1),
+      LocalDate.of(YEAR_2023, MONTH_10, DAY_1)
     )
 
-    val expectedJson = Json.obj(
-      "start" -> "2023-01-01",
-      "end"   -> "2023-12-31"
+    val expectedJson: JsObject = Json.obj(
+      "start" -> "2023-08-01",
+      "end"   -> "2023-10-01"
     )
 
     val validJson: String = Json.stringify(expectedJson)

--- a/test/models/CashTransactionDatesSpec.scala
+++ b/test/models/CashTransactionDatesSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{JsResultException, JsSuccess, Json}
+import utils.SpecBase
+
+import java.time.LocalDate
+
+class CashTransactionDatesSpec extends SpecBase {
+
+  "CashTransactionDates Reads" should {
+
+    "read valid JSON" in new Setup {
+      Json.parse(validJson).validate[CashTransactionDates] mustBe JsSuccess(model)
+    }
+
+    "throw error on invalid JSON when missing a field" in {
+      val invalidJson = Json.obj("start" -> "2023-01-01")
+
+      intercept[JsResultException] {
+        invalidJson.as[CashTransactionDates]
+      }
+    }
+  }
+
+  "CashTransactionDates Writes" should {
+
+    "write model to JSON" in new Setup {
+      Json.toJson(model) mustBe expectedJson
+    }
+  }
+
+  trait Setup {
+    val model = CashTransactionDates(
+      LocalDate.of(2023, 1, 1),
+      LocalDate.of(2023, 12, 31)
+    )
+
+    val expectedJson = Json.obj(
+      "start" -> "2023-01-01",
+      "end"   -> "2023-12-31"
+    )
+
+    val validJson: String = Json.stringify(expectedJson)
+  }
+}

--- a/test/models/CashTransactionsSpec.scala
+++ b/test/models/CashTransactionsSpec.scala
@@ -44,6 +44,19 @@ class CashTransactionsSpec extends SpecBase {
       (res \ "cashDailyStatements").as[Seq[CashDailyStatement]] mustBe Seq(cashDailyStatement)
       (res \ "maxTransactionsExceeded").as[Boolean] mustBe true
     }
+
+    "serialize to JSON correctly" in new Setup {
+      val model = CashTransactions(
+        pendingTransactions = Seq(declarations),
+        cashDailyStatements = Seq(cashDailyStatement),
+        maxTransactionsExceeded = Some(true)
+      )
+
+      val json = Json.toJson(model)
+      (json \ "pendingTransactions").as[Seq[Declaration]] mustBe Seq(declarations)
+      (json \ "cashDailyStatements").as[Seq[CashDailyStatement]] mustBe Seq(cashDailyStatement)
+      (json \ "maxTransactionsExceeded").as[Boolean] mustBe true
+    }
   }
 
   "EncryptedCashTransactions" must {
@@ -61,6 +74,20 @@ class CashTransactionsSpec extends SpecBase {
       (res \ "cashDailyStatements") mustBe a[JsUndefined]
       (res \ "maxTransactionsExceeded").as[Boolean] mustBe false
     }
+
+    "serialize to JSON correctly" in new Setup {
+      val model = EncryptedCashTransactions(
+        pendingTransactions = Seq(encryptedDeclaration),
+        cashDailyStatement = Seq(encryptedDailyStatements),
+        maxTransactionsExceeded = Some(false)
+      )
+
+      val json = Json.toJson(model)
+      (json \ "pendingTransactions").as[Seq[EncryptedDeclaration]] mustBe Seq(encryptedDeclaration)
+      (json \ "cashDailyStatement").as[Seq[EncryptedDailyStatements]] mustBe Seq(encryptedDailyStatements)
+      (json \ "maxTransactionsExceeded").as[Boolean] mustBe false
+    }
+
   }
 
   trait Setup {
@@ -68,6 +95,8 @@ class CashTransactionsSpec extends SpecBase {
     val year  = 2024
     val month = 5
     val day   = 5
+
+    val sMRN = "ic62zbad-75fa-445f-962b-cc92311686b8e"
 
     val nonce = "someNone"
 
@@ -132,6 +161,16 @@ class CashTransactionsSpec extends SpecBase {
         TaxGroup(ExciseDuty, twoThousand, taxTypes)
       ),
       secureMovementReferenceNumber = secureMovementReferenceNumber
+    )
+
+    val encryptedDailyStatements: EncryptedDailyStatements = EncryptedDailyStatements(
+      LocalDate.parse("2020-07-18"),
+      0.0,
+      1000.00,
+      Seq(
+        encryptedDeclaration
+      ),
+      Seq(Transaction(45.67, Payment, None), Transaction(-76.34, Withdrawal, Some("77665544")))
     )
 
     val encryptedCashTxn01: EncryptedCashTransactions = EncryptedCashTransactions(Seq(encryptedDeclaration), Nil, None)

--- a/test/models/CashTransactionsSpec.scala
+++ b/test/models/CashTransactionsSpec.scala
@@ -57,6 +57,40 @@ class CashTransactionsSpec extends SpecBase {
       (json \ "cashDailyStatements").as[Seq[CashDailyStatement]] mustBe Seq(cashDailyStatement)
       (json \ "maxTransactionsExceeded").as[Boolean] mustBe true
     }
+
+    "deserialize from JSON correctly" in new Setup {
+      val json = Json.obj(
+        "pendingTransactions"     -> Json.arr(Json.toJson(declarations)),
+        "cashDailyStatements"     -> Json.arr(Json.toJson(cashDailyStatement)),
+        "maxTransactionsExceeded" -> true
+      )
+
+      val result = json.as[CashTransactions]
+      result mustBe CashTransactions(Seq(declarations), Seq(cashDailyStatement), Some(true))
+    }
+
+    "serialize correctly when maxTransactionsExceeded is None" in new Setup {
+      val model = CashTransactions(
+        pendingTransactions = Seq(declarations),
+        cashDailyStatements = Seq(cashDailyStatement),
+        maxTransactionsExceeded = None
+      )
+
+      val json = Json.toJson(model)
+      (json \ "maxTransactionsExceeded").toOption mustBe empty
+    }
+
+    "availableTransactions returns true when pendingTransactions is non-empty" in new Setup {
+      CashTransactions(Seq(declarations), Seq.empty).availableTransactions mustBe true
+    }
+
+    "availableTransactions returns true when cashDailyStatements is non-empty" in new Setup {
+      CashTransactions(Seq.empty, Seq(cashDailyStatement)).availableTransactions mustBe true
+    }
+
+    "availableTransactions returns false when both pendingTransactions and cashDailyStatements are empty" in new Setup {
+      CashTransactions(Seq.empty, Seq.empty).availableTransactions mustBe false
+    }
   }
 
   "EncryptedCashTransactions" must {
@@ -86,6 +120,28 @@ class CashTransactionsSpec extends SpecBase {
       (json \ "pendingTransactions").as[Seq[EncryptedDeclaration]] mustBe Seq(encryptedDeclaration)
       (json \ "cashDailyStatement").as[Seq[EncryptedDailyStatements]] mustBe Seq(encryptedDailyStatements)
       (json \ "maxTransactionsExceeded").as[Boolean] mustBe false
+    }
+
+    "deserialize EncryptedCashTransactions from JSON correctly" in new Setup {
+      val json = Json.obj(
+        "pendingTransactions"     -> Json.arr(Json.toJson(encryptedDeclaration)),
+        "cashDailyStatement"      -> Json.arr(Json.toJson(encryptedDailyStatements)),
+        "maxTransactionsExceeded" -> false
+      )
+
+      val result = json.as[EncryptedCashTransactions]
+      result mustBe EncryptedCashTransactions(Seq(encryptedDeclaration), Seq(encryptedDailyStatements), Some(false))
+    }
+
+    "serialize EncryptedCashTransactions correctly when maxTransactionsExceeded is None" in new Setup {
+      val model = EncryptedCashTransactions(
+        pendingTransactions = Seq(encryptedDeclaration),
+        cashDailyStatement = Seq(encryptedDailyStatements),
+        maxTransactionsExceeded = None
+      )
+
+      val json = Json.toJson(model)
+      (json \ "maxTransactionsExceeded").toOption mustBe empty
     }
 
   }

--- a/test/models/DeclarationSpec.scala
+++ b/test/models/DeclarationSpec.scala
@@ -48,6 +48,35 @@ class DeclarationSpec extends SpecBase {
       val result: Declaration = Declaration.format.reads(json).get
       result mustBe declarationWithFieldsMissing
     }
+
+    "fail to deserialize invalid Declaration JSON (e.g., missing required field)" in new Setup {
+      val invalidJson: JsValue = Json.parse(
+        s"""{
+           |  "importerEori": "$importerEori",
+           |  "declarantReference": "$declarantReference",
+           |  "date": "$date",
+           |  "amount": $twoThousand
+           |}""".stripMargin
+      )
+
+      Declaration.format.reads(invalidJson) mustBe a[JsError]
+    }
+
+    "fail to deserialize Declaration with wrong data type" in new Setup {
+      val invalidJson: JsValue = Json.parse(
+        s"""{
+           |  "movementReferenceNumber": 123,
+           |  "importerEori": "$importerEori",
+           |  "declarantEori": "$declarantEori",
+           |  "date": "$date",
+           |  "amount": "$twoThousand",
+           |  "taxGroups": []
+           |}""".stripMargin
+      )
+
+      Declaration.format.reads(invalidJson) mustBe a[JsError]
+    }
+
   }
 
   "EncryptedDeclaration format" should {
@@ -57,6 +86,35 @@ class DeclarationSpec extends SpecBase {
       val result: EncryptedDeclaration = EncryptedDeclaration.format.reads(json).get
       result mustBe encryptedDeclaration
     }
+
+    "fail to deserialize invalid EncryptedDeclaration JSON" in new Setup {
+      val invalidJson: JsValue = Json.parse(
+        s"""{
+           |  "importerEori": "${crypto.encrypt(importerEori)}",
+           |  "declarantEori": "${crypto.encrypt(declarantEori)}",
+           |  "amount": $thousand,
+           |  "taxGroups": []
+           |}""".stripMargin
+      )
+
+      EncryptedDeclaration.format.reads(invalidJson) mustBe a[JsError]
+    }
+
+    "fail to deserialize EncryptedDeclaration with wrong data type" in new Setup {
+      val invalidJson: JsValue = Json.parse(
+        s"""{
+           |  "movementReferenceNumber": 123,
+           |  "importerEori": true,
+           |  "declarantEori": {},
+           |  "date": "not-a-date",
+           |  "amount": "1000",
+           |  "taxGroups": "not-an-array"
+           |}""".stripMargin
+      )
+
+      EncryptedDeclaration.format.reads(invalidJson) mustBe a[JsError]
+    }
+
   }
 
   trait Setup {

--- a/test/models/TaxGroupSpec.scala
+++ b/test/models/TaxGroupSpec.scala
@@ -89,7 +89,7 @@ class TaxGroupSpec extends SpecBase {
     }
 
     "fail to deserialize TaxGroup with incorrect types" in new Setup {
-      val invalidJson: JsValue = Json.obj("type" -> 123)
+      val invalidJson: JsValue      = Json.obj("type" -> 123)
       val result: JsResult[TaxType] = Json.fromJson[TaxType](invalidJson)
       result mustBe a[JsError]
     }

--- a/test/models/TaxGroupSpec.scala
+++ b/test/models/TaxGroupSpec.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import play.api.libs.json.{JsResultException, JsValue, Json}
+import play.api.libs.json.{JsError, JsObject, JsResult, JsResultException, JsValue, Json}
 import utils.SpecBase
 
 class TaxGroupSpec extends SpecBase {
@@ -40,6 +40,13 @@ class TaxGroupSpec extends SpecBase {
         invalidJson.as[TaxType]
       }
     }
+
+    "fail to deserialize TaxType with incorrect field types" in new Setup {
+      val invalidJson: JsObject     = Json.obj("reason" -> 123, "type" -> true, "amount" -> "not-a-number")
+      val result: JsResult[TaxType] = Json.fromJson[TaxType](invalidJson)
+      result mustBe a[JsError]
+    }
+
   }
 
   "TaxGroup" must {
@@ -79,6 +86,12 @@ class TaxGroupSpec extends SpecBase {
       intercept[RuntimeException] {
         invalidJson.as[TaxGroup]
       }
+    }
+
+    "fail to deserialize TaxGroup with incorrect types" in new Setup {
+      val invalidJson: JsValue = Json.obj("type" -> 123)
+      val result: JsResult[TaxType] = Json.fromJson[TaxType](invalidJson)
+      result mustBe a[JsError]
     }
   }
 

--- a/test/models/email/EmailResponsesSpec.scala
+++ b/test/models/email/EmailResponsesSpec.scala
@@ -16,7 +16,7 @@
 
 package models.email
 
-import play.api.libs.json.{JsSuccess, Json}
+import play.api.libs.json.{JsError, JsSuccess, Json}
 import utils.SpecBase
 
 class EmailResponsesSpec extends SpecBase {
@@ -35,6 +35,14 @@ class EmailResponsesSpec extends SpecBase {
       "performing Writes" in new Setup {
         Json.toJson(undelInfoEventOb) mustBe Json.parse(sampleResponseForUndeliverableEvent)
       }
+
+      "return JsError for invalid JSON" in new Setup {
+        val invalidJson = """{ "id": 123 }"""
+        import UndeliverableInformationEvent.format
+
+        Json.fromJson(Json.parse(invalidJson)) mustBe a[JsError]
+      }
+
     }
   }
 
@@ -53,6 +61,13 @@ class EmailResponsesSpec extends SpecBase {
         Json.toJson(undelInfoOb) mustBe Json.parse(sampleResponseForUndeliverableInfo)
       }
     }
+    "return JsError for invalid JSON" in new Setup {
+      val invalidJson = """{ "subject": 123 }"""
+      import UndeliverableInformation.format
+
+      Json.fromJson(Json.parse(invalidJson)) mustBe a[JsError]
+    }
+
   }
 
   "EmailResponse" must {
@@ -70,6 +85,13 @@ class EmailResponsesSpec extends SpecBase {
         Json.toJson(emailResponseOb) mustBe Json.parse(sampleEmailResponse)
       }
     }
+
+    "return JsError for invalid JSON" in new Setup {
+      val invalidJson = """{ "address": 456 }"""
+      import EmailResponse.format
+
+      Json.fromJson(Json.parse(invalidJson)) mustBe a[JsError]
+    }
   }
 
   "EmailVerifiedResponse.Reads" must {
@@ -79,6 +101,13 @@ class EmailResponsesSpec extends SpecBase {
       import EmailVerifiedResponse.format
 
       Json.fromJson(Json.parse(emailVerifiedResponse)) mustBe JsSuccess(emailVerifiedResponseOb)
+    }
+
+    "return JsError for invalid JSON" in new Setup {
+      val invalidJson = """{ "verifiedEmail": 999 }"""
+      import EmailVerifiedResponse.format
+
+      Json.fromJson(Json.parse(invalidJson)) mustBe a[JsError]
     }
   }
 
@@ -96,6 +125,13 @@ class EmailResponsesSpec extends SpecBase {
       import EmailUnverifiedResponse.format
 
       Json.fromJson(Json.parse(emailUnverifiedResponse)) mustBe JsSuccess(emailUnverifiedResponseOb)
+    }
+
+    "return JsError for invalid JSON" in new Setup {
+      val invalidJson = """{ "unVerifiedEmail": false }"""
+      import EmailUnverifiedResponse.format
+
+      Json.fromJson(Json.parse(invalidJson)) mustBe a[JsError]
     }
   }
 

--- a/test/models/request/CashDailyStatementRequestSpec.scala
+++ b/test/models/request/CashDailyStatementRequestSpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.request
+
+import play.api.libs.json.{JsResultException, JsValue, Json}
+import utils.SpecBase
+import utils.TestData.DAY_1
+
+import java.time.LocalDate
+
+class CashDailyStatementRequestSpec extends SpecBase {
+
+  "CashDailyStatementRequest" should {
+    "serialize and deserialize correctly" in new Setup {
+      Json.toJson(cashDailyStatementRequest) mustBe cashDailyStatementRequestJson
+      cashDailyStatementRequestJson.as[CashDailyStatementRequest] mustBe cashDailyStatementRequest
+    }
+
+    "fail to parse when required field is missing" in new Setup {
+      intercept[JsResultException] {
+        invalidJson.as[CashDailyStatementRequest]
+      }
+    }
+  }
+
+  "CashAccountStatementRequestDetail" should {
+    "serialize and deserialize correctly" in {
+      val detail = CashAccountStatementRequestDetail("GB123456789000", "test_can", "2023-01-01", "2023-01-31")
+      val json   = Json.toJson(detail)
+      json.as[CashAccountStatementRequestDetail] mustBe detail
+    }
+
+    "fail to parse invalid JSON" in {
+      val invalidJson = Json.parse("""{ "eori": "GB123456789000", "dateFrom": "2023-01-01", "dateTo": "2023-01-31" }""")
+      intercept[JsResultException] {
+        invalidJson.as[CashAccountStatementRequestDetail]
+      }
+    }
+
+    "CashAccountStatementRequestDetail" should {
+      "handle empty strings in fields" in {
+        val detail = CashAccountStatementRequestDetail("", "", "", "")
+        val json   = Json.toJson(detail)
+        json.as[CashAccountStatementRequestDetail] mustBe detail
+      }
+    }
+  }
+
+  trait Setup {
+    val cashDailyStatementRequest: CashDailyStatementRequest = CashDailyStatementRequest(
+      can = "test_can",
+      from = LocalDate.now().minusDays(DAY_1),
+      to = LocalDate.now()
+    )
+
+    val cashDailyStatementRequestJson: JsValue = Json.parse(
+      s"""
+        |{
+        |  "can": "test_can",
+        |  "from": "${LocalDate.now().minusDays(DAY_1)}",
+        |  "to": "${LocalDate.now()}"
+        |}
+        |""".stripMargin
+    )
+
+    val invalidJson: JsValue = Json.parse(
+      s"""
+         |{
+         |  "can": "test_can",
+         |  "to": "${LocalDate.now()}"
+         |}
+         |""".stripMargin
+    )
+  }
+}

--- a/test/models/request/CashTransactionsSearchRequestSpec.scala
+++ b/test/models/request/CashTransactionsSearchRequestSpec.scala
@@ -16,7 +16,7 @@
 
 package models.request
 
-import play.api.libs.json.{JsSuccess, Json}
+import play.api.libs.json.{JsResultException, JsSuccess, Json}
 import utils.SpecBase
 
 class CashTransactionsSearchRequestSpec extends SpecBase {
@@ -29,6 +29,52 @@ class CashTransactionsSearchRequestSpec extends SpecBase {
 
     "generate correct output using the Writes" in new Setup {
       Json.toJson(expectedDetails) mustBe Json.parse(requestJsValue)
+    }
+
+    "fail to deserialize when fields are missing" in new Setup {
+      Json.parse(missingFieldsJson).validate[CashAccountTransactionSearchRequestDetails].isError mustBe true
+    }
+
+    "fail to deserialize when JSON contains invalid values" in new Setup {
+      Json.parse(invalidJson).validate[CashAccountTransactionSearchRequestDetails].isError mustBe true
+    }
+
+    "throw exception when paramName is missing in DeclarationDetailsSearch" in {
+      val missingFieldJson =
+        """{
+          | "paramValue": "18GB9JLC3CU1LFGVR8"
+          |}""".stripMargin
+
+      intercept[JsResultException] {
+        Json.parse(missingFieldJson).as[DeclarationDetailsSearch]
+      }
+    }
+
+    "serialize and deserialize DeclarationDetailsSearch" in {
+      val details = DeclarationDetailsSearch(ParamName.MRN, "18GB9JLC3CU1LFGVR8")
+      val json    = Json.toJson(details)
+      json mustBe Json.parse("""{"paramName":"MRN","paramValue":"18GB9JLC3CU1LFGVR8"}""")
+      json.validate[DeclarationDetailsSearch] mustBe JsSuccess(details)
+    }
+
+    "throw exception for invalid paramName in DeclarationDetailsSearch" in {
+      val invalidJson = """{ "paramName": "INVALID", "paramValue": "someValue" }"""
+
+      intercept[NoSuchElementException] {
+        Json.parse(invalidJson).as[DeclarationDetailsSearch]
+      }
+    }
+
+    "serialize and deserialize CashAccountPaymentDetails" in {
+      val payment = CashAccountPaymentDetails(1500.0, Some("2022-07-01"), Some("2022-07-31"))
+      val json    = Json.toJson(payment)
+      json mustBe Json.parse("""{"amount":1500.0,"dateFrom":"2022-07-01","dateTo":"2022-07-31"}""")
+      json.validate[CashAccountPaymentDetails] mustBe JsSuccess(payment)
+    }
+
+    "deserialize CashAccountPaymentDetails with missing optional dates" in {
+      val json = Json.parse("""{"amount":1500.0}""")
+      json.validate[CashAccountPaymentDetails] mustBe JsSuccess(CashAccountPaymentDetails(1500.0, None, None))
     }
   }
 
@@ -61,6 +107,30 @@ class CashTransactionsSearchRequestSpec extends SpecBase {
          |},
          |"cashAccountPaymentDetails": {
          |  "amount": 1500.0,
+         |  "dateFrom": "2022-07-01",
+         |  "dateTo": "2022-07-31"
+         |}
+         |}""".stripMargin
+
+    val missingFieldsJson: String =
+      s"""
+         |{
+         |"ownerEORI": "$ownerEORI",
+         |"searchType": "$searchType"
+         |}
+         |""".stripMargin
+
+    val invalidJson: String =
+      s"""{
+         |"can": "$can",
+         |"ownerEORI": "$ownerEORI",
+         |"searchType": "$searchType",
+         |"declarationDetails": {
+         |  "paramName": "MRN",
+         |  "paramValue": "18GB9JLC3CU1LFGVR8"
+         |},
+         |"cashAccountPaymentDetails": {
+         |  "amount": "not-a-number",
          |  "dateFrom": "2022-07-01",
          |  "dateTo": "2022-07-31"
          |}

--- a/test/models/response/CashTransactionSearchResponseSpec.scala
+++ b/test/models/response/CashTransactionSearchResponseSpec.scala
@@ -16,7 +16,7 @@
 
 package models.response
 
-import play.api.libs.json.{JsSuccess, Json}
+import play.api.libs.json.{JsSuccess, JsValue, Json}
 import utils.SpecBase
 
 class CashTransactionSearchResponseSpec extends SpecBase {
@@ -31,6 +31,251 @@ class CashTransactionSearchResponseSpec extends SpecBase {
 
     "generate correct output using Writes with all fields" in new Setup {
       Json.toJson(expectedResponseDetail) mustBe Json.parse(responseJsValue)
+    }
+  }
+
+  "CashAccountTransactionSearchResponseContainer" must {
+
+    "deserialize full JSON with responseCommon and responseDetail" in new Setup {
+      val jsonStr: String =
+        s"""
+           |{
+           |  "cashAccountTransactionSearchResponse": {
+           |    "responseCommon": {
+           |      "status": "OK",
+           |      "statusText": "Success",
+           |      "processingDate": "2022-07-23",
+           |      "returnParameters": [
+           |        { "paramName": "PARAM1", "paramValue": "VALUE1" }
+           |      ]
+           |    },
+           |    "responseDetail": $responseJsValue
+           |  }
+           |}
+           |""".stripMargin
+
+      val expectedContainer: CashAccountTransactionSearchResponseContainer =
+        CashAccountTransactionSearchResponseContainer(
+          CashAccountTransactionSearchResponse(
+            responseCommon = CashTransactionsResponseCommon(
+              status = "OK",
+              statusText = Some("Success"),
+              processingDate = "2022-07-23",
+              returnParameters = Some(Array(ReturnParameter("PARAM1", "VALUE1")))
+            ),
+            responseDetail = Some(expectedResponseDetail)
+          )
+        )
+
+      Json.toJson(Json.parse(jsonStr).validate[CashAccountTransactionSearchResponseContainer].get) mustBe Json.toJson(
+        expectedContainer
+      )
+    }
+
+    "serialize full object to JSON correctly" in new Setup {
+      val container: CashAccountTransactionSearchResponseContainer = CashAccountTransactionSearchResponseContainer(
+        CashAccountTransactionSearchResponse(
+          responseCommon = CashTransactionsResponseCommon(
+            status = "OK",
+            statusText = Some("Success"),
+            processingDate = "2022-07-23",
+            returnParameters = Some(Array(ReturnParameter("PARAM1", "VALUE1")))
+          ),
+          responseDetail = Some(expectedResponseDetail)
+        )
+      )
+
+      val expectedJson: JsValue = Json.parse(
+        s"""
+           |{
+           |  "cashAccountTransactionSearchResponse": {
+           |    "responseCommon": {
+           |      "status": "OK",
+           |      "statusText": "Success",
+           |      "processingDate": "2022-07-23",
+           |      "returnParameters": [
+           |        { "paramName": "PARAM1", "paramValue": "VALUE1" }
+           |      ]
+           |    },
+           |    "responseDetail": $responseJsValue
+           |  }
+           |}
+           |""".stripMargin
+      )
+
+      Json.toJson(container) mustBe expectedJson
+    }
+  }
+
+  "ReturnParameter" must {
+    "deserialize valid JSON" in {
+      val json = Json.parse("""{"paramName": "foo", "paramValue": "bar"}""")
+      json.validate[ReturnParameter] mustBe JsSuccess(ReturnParameter("foo", "bar"))
+    }
+
+    "fail on missing required fields" in {
+      val json = Json.parse("""{"paramName": "foo"}""")
+      json.validate[ReturnParameter].isError mustBe true
+    }
+
+    "serialize to correct JSON" in {
+      Json.toJson(ReturnParameter("foo", "bar")) mustBe Json.parse(
+        """{"paramName":"foo","paramValue":"bar"}"""
+      )
+    }
+  }
+
+  "EoriData" must {
+    "serialize and deserialize correctly" in {
+      val data = EoriData("GB123", "name")
+      Json.toJson(data).validate[EoriData] mustBe JsSuccess(data)
+    }
+
+    "fail on missing fields" in {
+      val json = Json.parse("""{"eoriNumber": "GB123"}""")
+      json.validate[EoriData].isError mustBe true
+    }
+  }
+
+  "EoriDataContainer" must {
+    "serialize and deserialize correctly" in {
+      val container = EoriDataContainer(EoriData("GB123", "name"))
+      Json.toJson(container).validate[EoriDataContainer] mustBe JsSuccess(container)
+    }
+  }
+
+  "TaxTypeWithSecurity" must {
+    "handle optional reasonForSecurity" in {
+      val json = Json.parse("""{"taxTypeID": "A10", "amount": 123.45}""")
+      json.validate[TaxTypeWithSecurity].isSuccess mustBe true
+    }
+
+    "fail with missing taxTypeID" in {
+      val json = Json.parse("""{"amount": 123.45}""")
+      json.validate[TaxTypeWithSecurity].isError mustBe true
+    }
+  }
+
+  "TaxGroupSearch" must {
+    "serialize/deserialize taxTypes properly" in {
+      val tax =
+        TaxGroupSearch("VAT", 200.0, Seq(TaxTypeWithSecurityContainer(TaxTypeWithSecurity(Some("Duty"), "A10", 200.0))))
+      Json.toJson(tax).validate[TaxGroupSearch] mustBe JsSuccess(tax)
+    }
+  }
+
+  "DeclarationSearch" must {
+    "serialize/deserialize with optional fields omitted" in {
+      val declaration =
+        DeclarationSearch("id", "declarant", None, None, "importer", "2022-01-01", "2022-01-01", 100.0, Nil)
+      val json        = Json.toJson(declaration)
+      json.validate[DeclarationSearch] mustBe JsSuccess(declaration)
+    }
+
+    "fail on missing required fields" in {
+      val json = Json.parse("""{"declarationID": "id"}""")
+      json.validate[DeclarationSearch].isError mustBe true
+    }
+  }
+
+  "DeclarationWrapper" must {
+    "wrap and unwrap correctly" in {
+      val wrapper = DeclarationWrapper(
+        DeclarationSearch("id", "decl", None, None, "imp", "2022-01-01", "2022-01-01", 0.0, Nil)
+      )
+      Json.toJson(wrapper).validate[DeclarationWrapper] mustBe JsSuccess(wrapper)
+    }
+  }
+
+  "PaymentsWithdrawalsAndTransfer" must {
+    "serialize/deserialize with all fields" in {
+      val payment = PaymentsWithdrawalsAndTransfer(
+        "2022-07-20",
+        "2022-07-21",
+        "REF123456",
+        1500.0,
+        PaymentType.Payment,
+        Some("12345678"),
+        Some("12-34-56")
+      )
+      Json.toJson(payment).validate[PaymentsWithdrawalsAndTransfer] mustBe JsSuccess(payment)
+    }
+
+    "fail with invalid type enum" in {
+      val invalidJson = Json.parse(
+        """{
+          |  "valueDate": "2022-07-20",
+          |  "postingDate": "2022-07-21",
+          |  "paymentReference": "REF123456",
+          |  "amount": 1500.0,
+          |  "type": "InvalidType"
+          |}""".stripMargin
+      )
+
+      intercept[NoSuchElementException] {
+        invalidJson.as[PaymentsWithdrawalsAndTransfer]
+      }
+    }
+
+    "handle missing optional fields gracefully" in {
+      val json = Json.parse(
+        """{
+          |  "valueDate": "2022-07-20",
+          |  "postingDate": "2022-07-21",
+          |  "paymentReference": "REF123456",
+          |  "amount": 1500.0,
+          |  "type": "Payment"
+          |}""".stripMargin
+      )
+      json.validate[PaymentsWithdrawalsAndTransfer].isSuccess mustBe true
+    }
+  }
+
+  "PaymentsWithdrawalsAndTransferContainer" must {
+    "serialize/deserialize correctly" in {
+      val container = PaymentsWithdrawalsAndTransferContainer(
+        PaymentsWithdrawalsAndTransfer("2022-07-20", "2022-07-21", "REF123456", 1500.0, PaymentType.Payment)
+      )
+      Json.toJson(container).validate[PaymentsWithdrawalsAndTransferContainer] mustBe JsSuccess(container)
+    }
+  }
+
+  "CashAccountTransactionSearchResponse" must {
+    "serialize and deserialize full structure with Some(responseDetail)" in new Setup {
+      val response: CashAccountTransactionSearchResponse = CashAccountTransactionSearchResponse(
+        CashTransactionsResponseCommon("OK", Some("text"), "2022-07-23"),
+        Some(expectedResponseDetail)
+      )
+      Json.toJson(response).validate[CashAccountTransactionSearchResponse] mustBe JsSuccess(response)
+    }
+
+    "handle None for optional responseDetail" in {
+      val response = CashAccountTransactionSearchResponse(
+        CashTransactionsResponseCommon("OK", None, "2022-07-23"),
+        None
+      )
+      Json.toJson(response).validate[CashAccountTransactionSearchResponse] mustBe JsSuccess(response)
+    }
+  }
+
+  "CashAccountTransactionSearchResponseContainer" must {
+    "serialize and deserialize full structure" in new Setup {
+      val container: CashAccountTransactionSearchResponseContainer = CashAccountTransactionSearchResponseContainer(
+        CashAccountTransactionSearchResponse(
+          CashTransactionsResponseCommon("OK", Some("Success"), "2022-07-23", Some(Array(ReturnParameter("p", "v")))),
+          Some(expectedResponseDetail)
+        )
+      )
+
+      val json: JsValue                                         = Json.toJson(container)
+      val parsed: CashAccountTransactionSearchResponseContainer = json.as[CashAccountTransactionSearchResponseContainer]
+
+      Json.toJson(parsed) mustBe Json.toJson(container)
+    }
+
+    "fail on missing required field in responseCommon" in {
+      val json = Json.parse("""{ "cashAccountTransactionSearchResponse": { "responseDetail": {} } }""")
+      json.validate[CashAccountTransactionSearchResponseContainer].isError mustBe true
     }
   }
 

--- a/test/utils/TestData.scala
+++ b/test/utils/TestData.scala
@@ -42,8 +42,10 @@ object TestData {
   val DAY_16 = 16
   val DAY_17 = 17
 
+  val MONTH_2   = 2
   val MONTH_8   = 8
   val MONTH_10  = 10
+  val YEAR_2020 = 2020
   val YEAR_2021 = 2021
   val YEAR_2022 = 2022
   val YEAR_2023 = 2023

--- a/test/viewmodels/SummaryListRowSpec.scala
+++ b/test/viewmodels/SummaryListRowSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels
+
+import org.scalatest.matchers.should.Matchers.shouldBe
+import uk.gov.hmrc.govukfrontend.views.Aliases.{Actions, HtmlContent, Value}
+import utils.SpecBase
+
+class SummaryListRowSpec extends SpecBase {
+  "SummaryListRow" should {
+
+    "construct properly with all fields provided" in {
+      val value1  = Value(content = HtmlContent("Value 1"))
+      val value2  = Value(content = HtmlContent("Value 2"))
+      val actions = Actions(items = Seq.empty)
+      val row     = SummaryListRow(
+        value = value1,
+        secondValue = Some(value2),
+        classes = "some-css-class",
+        actions = Some(actions)
+      )
+
+      row.value       shouldBe value1
+      row.secondValue shouldBe Some(value2)
+      row.classes     shouldBe "some-css-class"
+      row.actions     shouldBe Some(actions)
+    }
+
+    "construct properly when optional fields are not provided" in {
+      val value1 = Value(content = HtmlContent("Only Value"))
+      val row    = SummaryListRow(
+        value = value1,
+        secondValue = None,
+        classes = "single-value"
+      )
+
+      row.value       shouldBe value1
+      row.secondValue shouldBe None
+      row.classes     shouldBe "single-value"
+      row.actions     shouldBe None
+    }
+  }
+}

--- a/test/views/components/PaymentHeaderSpec.scala
+++ b/test/views/components/PaymentHeaderSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components
+
+import uk.gov.hmrc.govukfrontend.views.Aliases
+import uk.gov.hmrc.govukfrontend.views.Aliases.{HeadCell, HtmlContent}
+import utils.SpecBase
+
+class PaymentHeaderSpec extends SpecBase {
+
+  "apply" should {
+
+    "produce correct output" in new Setup {
+
+      val headerOb: Seq[HeadCell] = PaymentHeader()
+
+      headerOb.size mustBe 4
+      headerOb must be(an[Seq[HeadCell]])
+    }
+  }
+
+  trait Setup {
+    protected def expectedHeaderCells: Seq[HeadCell] =
+      Seq(
+        HeadCell(
+          classes = "first-column-width",
+          content = HtmlContent(s"""
+                <abbr title="${messages("cf.cash-account.detail.date")}">
+                    ${messages("cf.cash-account.detail.date")}
+                </abbr>
+                """)
+        ),
+        HeadCell(
+          classes = "second-column-width",
+          content = HtmlContent(s"""
+                <abbr title="${messages("cf.cash-account.detail.transaction-type")}">
+                ${messages("cf.cash-account.detail.transaction-type")}
+                </abbr>
+                """)
+        ),
+        HeadCell(
+          content = HtmlContent(s"""
+                <abbr title="${messages("cf.cash-account.detail.credit")}">
+                ${messages("cf.cash-account.detail.credit")}
+                </abbr>
+                """)
+        ),
+        HeadCell(
+          format = Some("numeric"),
+          content = HtmlContent(s"""
+                <abbr title="${messages("cf.cash-account.detail.debit")}">
+                ${messages("cf.cash-account.detail.debit")}
+                </abbr>
+                """)
+        )
+      )
+  }
+}

--- a/test/views/components/TransactionRowSpec.scala
+++ b/test/views/components/TransactionRowSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components
+
+import org.scalatest.matchers.should.Matchers.{should, shouldBe}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.table.TableRow
+import utils.SpecBase
+
+class TransactionRowSpec extends SpecBase {
+
+  "TransactionRow" should {
+    "return a sequence of two correctly constructed TableRow instances" in {
+      val transactionSpan    = "Date"
+      val transactionMessage = "01 Jan 2025"
+      val amountSpan         = "Amount"
+      val amount             = "£123.45"
+
+      val result: Seq[TableRow] = TransactionRow(transactionSpan, transactionMessage, amountSpan, amount)
+
+      result should have size 2
+
+      val firstRow = result.head
+      firstRow.classes           shouldBe "govuk-table__cell govuk-!-font-weight-regular"
+      firstRow.content.asHtml.body should include(
+        s"""<span class="hmrc-responsive-table__heading" aria-hidden="true">$transactionSpan</span>"""
+      )
+      firstRow.content.asHtml.body should include(transactionMessage)
+
+      val secondRow = result(1)
+      secondRow.classes           shouldBe "govuk-table__cell--numeric amount"
+      secondRow.content.asHtml.body should include(
+        s"""<span class="hmrc-responsive-table__heading amount" aria-hidden="true">$amountSpan</span>"""
+      )
+      secondRow.content.asHtml.body should include(amount)
+    }
+  }
+}

--- a/test/views/helpers/PageTitleSpec.scala
+++ b/test/views/helpers/PageTitleSpec.scala
@@ -33,6 +33,12 @@ class PageTitleSpec extends SpecBase {
 
       res mustBe Some(" - Manage import duties and VAT accounts - GOV.UK")
     }
+
+    "return correct string for None title" in {
+      val res: Option[String] = PageTitle.fullPageTitle(None)
+
+      res mustBe Some("Manage import duties and VAT accounts - GOV.UK")
+    }
   }
 
 }


### PR DESCRIPTION
- [ ] Added tests for models to address Json.Format
- [ ] add more tests for existing classes
- [ ] upgrade scoverage version to 2.3.1
- [ ] coverageFailOnMinimum flag has been enabled
- [ ] suppress platform generated css warnings
- [ ] minor indentation update (scala formatting) in two files in normal code
- [ ] Exclude certain files related to cash_account as soon to be inactive
- [ ] Exclude repository as unable to test
- [ ] Platform version has not been updated to 9.16.0 on purpose, to avoid the (existing) performance tests issue with version 9.16.0